### PR TITLE
chore: uv lock upgrade (uvicorn 0.42.0) + Linux E2E secrets fallback

### DIFF
--- a/scripts/gateway_e2e_run.sh
+++ b/scripts/gateway_e2e_run.sh
@@ -178,43 +178,49 @@ if [ "${INJECT_API_KEY}" = "true" ]; then
     log_info "Injecting API key into catalog env section"
 
     # Add NEXTDNS_API_KEY to the env section of the catalog.
-    cd ${PROJECT_DIR}
-    uv run python3 -c "
-import yaml
+    # NOTE: Keep the key out of the command line (ps-visible) and avoid brittle shell interpolation.
+    if (
+        cd "${PROJECT_DIR}" \
+        && TEMP_CATALOG="${TEMP_CATALOG}" NEXTDNS_API_KEY="${NEXTDNS_API_KEY}" uv run python3 - <<'PY'
+import os
 import sys
 
-with open('${TEMP_CATALOG}', 'r') as f:
+import yaml
+
+temp_catalog = os.environ["TEMP_CATALOG"]
+api_key = os.environ["NEXTDNS_API_KEY"]
+
+with open(temp_catalog, "r", encoding="utf-8") as f:
     catalog = yaml.safe_load(f)
 
-if 'registry' in catalog and 'nextdns' in catalog['registry']:
-    if 'env' not in catalog['registry']['nextdns']:
-        catalog['registry']['nextdns']['env'] = []
-
-    env_list = catalog['registry']['nextdns']['env']
-    found = False
-    for env_var in env_list:
-        if env_var.get('name') == 'NEXTDNS_API_KEY':
-            env_var['value'] = '${NEXTDNS_API_KEY}'
-            env_var['description'] = env_var.get('description') or 'NextDNS API key (injected at runtime)'
-            found = True
-            break
-
-    if not found:
-        env_list.insert(0, {
-            'name': 'NEXTDNS_API_KEY',
-            'value': '${NEXTDNS_API_KEY}',
-            'description': 'NextDNS API key (injected at runtime)'
-        })
-
-    with open('${TEMP_CATALOG}', 'w') as f:
-        yaml.dump(catalog, f, default_flow_style=False, sort_keys=False)
-
-    sys.exit(0)
-else:
+registry = catalog.get("registry", {}) if isinstance(catalog, dict) else {}
+nextdns = registry.get("nextdns") if isinstance(registry, dict) else None
+if not isinstance(nextdns, dict):
     sys.exit(1)
-"
 
-    if [ $? -eq 0 ]; then
+env_list = nextdns.setdefault("env", [])
+if not isinstance(env_list, list):
+    sys.exit(1)
+
+for env_var in env_list:
+    if isinstance(env_var, dict) and env_var.get("name") == "NEXTDNS_API_KEY":
+        env_var["value"] = api_key
+        env_var["description"] = env_var.get("description") or "NextDNS API key (injected at runtime)"
+        break
+else:
+    env_list.insert(
+        0,
+        {
+            "name": "NEXTDNS_API_KEY",
+            "value": api_key,
+            "description": "NextDNS API key (injected at runtime)",
+        },
+    )
+
+with open(temp_catalog, "w", encoding="utf-8") as f:
+    yaml.dump(catalog, f, default_flow_style=False, sort_keys=False)
+PY
+    ); then
         log_success "API key injected into catalog"
     else
         log_error "Failed to inject API key into catalog"

--- a/scripts/gateway_e2e_run.sh
+++ b/scripts/gateway_e2e_run.sh
@@ -157,12 +157,27 @@ log_info "Step 2: Preparing catalog..."
 TEMP_CATALOG="${ARTIFACTS_DIR}/catalog-temp.yaml"
 cp "${PROJECT_DIR}/catalog.yaml" "${TEMP_CATALOG}"
 
-# In CI, inject API key directly into env section (bypass secrets mechanism)
-if [ "${CI:-false}" = "true" ]; then
-    log_info "CI environment detected - injecting API key into catalog env section"
-    
-    # Add NEXTDNS_API_KEY to the env section of the catalog
-    # This bypasses the secrets mechanism which may not work reliably in CI
+# Determine whether to inject the API key directly into the catalog env section.
+#
+# Rationale:
+# - On Linux (no Docker Desktop), the Docker MCP secrets engine may be unavailable.
+# - When secrets are unavailable, the server starts without NEXTDNS_API_KEY and all tool calls fail with authRequired.
+#
+# Injection keeps credentials ephemeral (catalog is copied to artifacts, imported, then deleted).
+INJECT_API_KEY="${CI:-false}"
+if [ "${INJECT_API_KEY}" != "true" ]; then
+    if [ ! -f "$HOME/.docker/mcp/secrets.env" ]; then
+        if ! docker mcp secret ls >/dev/null 2>&1; then
+            INJECT_API_KEY="true"
+            log_warn "Docker MCP secrets engine unavailable and no file-based secrets detected; injecting NEXTDNS_API_KEY into catalog env for this run"
+        fi
+    fi
+fi
+
+if [ "${INJECT_API_KEY}" = "true" ]; then
+    log_info "Injecting API key into catalog env section"
+
+    # Add NEXTDNS_API_KEY to the env section of the catalog.
     cd ${PROJECT_DIR}
     uv run python3 -c "
 import yaml
@@ -171,35 +186,34 @@ import sys
 with open('${TEMP_CATALOG}', 'r') as f:
     catalog = yaml.safe_load(f)
 
-# Add API key to env section
 if 'registry' in catalog and 'nextdns' in catalog['registry']:
     if 'env' not in catalog['registry']['nextdns']:
         catalog['registry']['nextdns']['env'] = []
-    
-    # Add or update NEXTDNS_API_KEY
+
     env_list = catalog['registry']['nextdns']['env']
     found = False
     for env_var in env_list:
         if env_var.get('name') == 'NEXTDNS_API_KEY':
             env_var['value'] = '${NEXTDNS_API_KEY}'
+            env_var['description'] = env_var.get('description') or 'NextDNS API key (injected at runtime)'
             found = True
             break
-    
+
     if not found:
         env_list.insert(0, {
             'name': 'NEXTDNS_API_KEY',
             'value': '${NEXTDNS_API_KEY}',
-            'description': 'NextDNS API key (injected in CI)'
+            'description': 'NextDNS API key (injected at runtime)'
         })
-    
+
     with open('${TEMP_CATALOG}', 'w') as f:
         yaml.dump(catalog, f, default_flow_style=False, sort_keys=False)
-    
+
     sys.exit(0)
 else:
     sys.exit(1)
 "
-    
+
     if [ $? -eq 0 ]; then
         log_success "API key injected into catalog"
     else
@@ -276,8 +290,11 @@ fi
 # Debug: Show API key length (not the actual key)
 log_info "API key length: ${#NEXTDNS_API_KEY} characters"
 
-# Check if we're in CI or if file-based secrets already exist
-if [ "${CI:-false}" = "true" ]; then
+# Check if we're using injected env, CI/file-based secrets, or Docker Desktop secrets.
+if [ "${INJECT_API_KEY:-false}" = "true" ]; then
+    log_info "API key provided via catalog env injection"
+    log_success "API key configured via catalog env"
+elif [ "${CI:-false}" = "true" ]; then
     log_info "CI environment detected - using file-based secrets from ~/.docker/mcp/secrets.env"
     log_success "API key configured via file-based secrets"
 elif [ -f "$HOME/.docker/mcp/secrets.env" ]; then

--- a/uv.lock
+++ b/uv.lock
@@ -1262,15 +1262,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.41.0"
+version = "0.42.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359", size = 68830, upload-time = "2026-03-16T06:19:48.325Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `uv lock --upgrade` updated **uvicorn 0.41.0 → 0.42.0**
- Fixed `scripts/gateway_e2e_run.sh` to **inject `NEXTDNS_API_KEY` into the catalog env** when the Docker MCP secrets engine is unavailable (common on Linux without Docker Desktop). This prevents E2E runs from failing with `authRequired`.

## Validation
- Format: `uv run isort src/ tests/` and `uv run black src/ tests/`
- Type check: `uv run mypy src/` ✅
- Unit tests: `uv run pytest tests/unit --cov=src/nextdns_mcp` ✅ (100% coverage)
- E2E: `cd scripts && ./gateway_e2e_run.sh` ✅ (75/75 tools executed; 100% pass)

## Notes
- The API key is injected into a *temporary* catalog copy under `artifacts/` during the run and removed immediately after import; it is not committed.
