### PR TITLE
feat: ensure quality and E2E checks run before Docker publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,16 +34,35 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  quality:
+    name: Run Quality Checks
+    # Only run this if we are NOT triggered by a workflow_run (because those already passed quality)
+    if: github.event_name != 'workflow_run'
+    uses: ./.github/workflows/unit-tests.yml
+
+  e2e:
+    name: Run E2E Tests
+    # Only run this if we are NOT triggered by a workflow_run
+    if: github.event_name != 'workflow_run'
+    needs: quality
+    uses: ./.github/workflows/e2e-mcp-gateway.yml
+    secrets: inherit
+
   docker-publish:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
-    
-    # Run on main branch completion, tags, manual dispatch, or nightly schedule
+    # Wait for e2e if it was scheduled to run
+    needs: [e2e]
+    # Handle the 'if' logic carefully to allow workflow_run (which skips needs) or successful needs
     if: |
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') ||
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'schedule'
+      always() &&
+      (
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') ||
+        (
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') &&
+          needs.e2e.result == 'success'
+        )
+      )
     
     steps:
       - name: Wait for all required workflows to complete

--- a/.github/workflows/e2e-mcp-gateway.yml
+++ b/.github/workflows/e2e-mcp-gateway.yml
@@ -1,6 +1,7 @@
 name: E2E MCP Gateway
 
 on:
+  workflow_call:
   workflow_dispatch:
     inputs:
       allow_live_writes:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,6 +1,14 @@
 name: Unit Tests
 
 on:
+  workflow_call:
+    outputs:
+      coverage:
+        description: "Overall coverage percentage"
+        value: ${{ jobs.unit-tests.outputs.coverage }}
+      failed_files:
+        description: "List of files below threshold"
+        value: ${{ jobs.unit-tests.outputs.failed_files }}
   push:
     branches: 
       - main  # Only run on main branch pushes
@@ -14,6 +22,9 @@ permissions:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    outputs:
+      coverage: ${{ steps.tests.outputs.coverage }}
+      failed_files: ${{ steps.tests.outputs.failed_files }}
     
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR fixes the issue where the Docker publish workflow was skipping E2E tests for nightly rebuilds and manual triggers.

### Changes:
- **Dependency Chain**: Added explicit `quality` and `e2e` jobs to `docker-publish.yml`.
- **Conditional Execution**: These checks run for manual (`workflow_dispatch`), scheduled (`schedule`), and tag (`push`) triggers. 
- **Redundancy Prevention**: For `workflow_run` triggers (triggered by the main CI), the workflow still uses its internal wait-and-verify logic to avoid running tests twice on the same commit.
- **Safety**: The Docker image will only be pushed if the E2E tests pass for that specific run.