### PR TITLE
fix: update Dockerfile image version label to 2.0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ LABEL org.opencontainers.image.description="Model Context Protocol server for Ne
 LABEL org.opencontainers.image.authors="NextDNS MCP Contributors"
 LABEL org.opencontainers.image.source="https://github.com/dmeiser/nextdns-mcp"
 LABEL org.opencontainers.image.documentation="https://github.com/dmeiser/nextdns-mcp/blob/main/README.md"
-LABEL org.opencontainers.image.version="2.0.0"
+LABEL org.opencontainers.image.version="2.0.4"
 LABEL org.opencontainers.image.licenses="MIT"
 
 # MCP-specific labels


### PR DESCRIPTION
The Dockerfile had a hardcoded version label of 2.0.0. This PR updates it to match the current project version 2.0.4.