### PR TITLE
fix: remove exact version tag from scheduled daily builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -209,8 +209,8 @@ jobs:
             type=raw,value=latest,enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
             # Tag with commit SHA
             type=sha,prefix=,format=short
-            # Exact version and floating major/minor tags for main or schedule
-            type=raw,value=${{ steps.version.outputs.version }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+            # Exact version tag for main branch or manual dispatch only (NOT for schedule)
+            type=raw,value=${{ steps.version.outputs.version }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch' }}
             type=raw,value=${{ steps.version.outputs.major }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
             type=raw,value=${{ steps.version.outputs.major_minor }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
             # Semantic version tags from git tags (v1.0.0 -> 1.0.0, 1.0, 1)

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ LABEL org.opencontainers.image.description="Model Context Protocol server for Ne
 LABEL org.opencontainers.image.authors="NextDNS MCP Contributors"
 LABEL org.opencontainers.image.source="https://github.com/dmeiser/nextdns-mcp"
 LABEL org.opencontainers.image.documentation="https://github.com/dmeiser/nextdns-mcp/blob/main/README.md"
-LABEL org.opencontainers.image.version="2.0.7"
+LABEL org.opencontainers.image.version="2.0.8"
 LABEL org.opencontainers.image.licenses="MIT"
 
 # MCP-specific labels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nextdns-mcp"
-version = "2.0.7"
+version = "2.0.8"
 description = "NextDNS MCP Server - Model Context Protocol server for NextDNS API built with FastMCP"
 authors = [{name = "NextDNS MCP Contributors"}]
 license = {text = "MIT"}

--- a/src/nextdns_mcp/__init__.py
+++ b/src/nextdns_mcp/__init__.py
@@ -3,4 +3,4 @@
 SPDX-License-Identifier: MIT
 """
 
-__version__ = "2.0.7"
+__version__ = "2.0.8"


### PR DESCRIPTION
Fixes the issue where scheduled daily builds were incorrectly tagged with the full version number (e.g., 2.0.7).

Daily builds should only receive: latest, short SHA, major version (2), and major.minor version (2.0).

The exact version tag should only be applied on pushes to main, workflow_dispatch, or git tag pushes.