### PR TITLE
fix: don't push subminor version tag on scheduled (cron) builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -209,8 +209,8 @@ jobs:
             type=raw,value=latest,enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
             # Tag with commit SHA
             type=sha,prefix=,format=short
-            # Exact version tag for main branch or manual dispatch only (NOT for schedule)
-            type=raw,value=${{ steps.version.outputs.version }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch' }}
+            # Exact version tag for workflow_run (new commit on main) or manual dispatch only (NOT for schedule)
+            type=raw,value=${{ steps.version.outputs.version }},enable=${{ github.event_name == 'workflow_run' || github.event_name == 'workflow_dispatch' }}
             type=raw,value=${{ steps.version.outputs.major }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
             type=raw,value=${{ steps.version.outputs.major_minor }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
             # Semantic version tags from git tags (v1.0.0 -> 1.0.0, 1.0, 1)


### PR DESCRIPTION
## Problem

Scheduled daily builds were incorrectly re-pushing the exact subminor version tag (e.g. `2.0.8`) on every run. Evidence:

- 2026-04-12: tags `latest`, `2.0.8`, `2`, `2.0`, `1817cef`
- 2026-04-11: tags `latest`, `2.0.8`, `2`, `2.0`, `1817cef`

Subminor tags should be idempotent — created once when the version is released, never overwritten.

## Root Cause

In the `Extract metadata for Docker` step, the `enable` expression for the exact version tag was:

```
enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch' }}
```

During a scheduled run, GitHub Actions sets `github.ref_type = 'branch'` and `github.ref_name = 'main'` (the default branch), so the first half of the OR evaluated to **true** and the subminor tag was pushed every night — despite the comment saying "NOT for schedule".

## Fix

Replace the ambiguous branch-name check with an explicit event-name check:

| Event | Before | After |
|---|---|---|
| `workflow_run` (new commit on main) | ✅ push subminor | ✅ push subminor |
| `workflow_dispatch` (manual) | ✅ push subminor | ✅ push subminor |
| `schedule` (nightly cron) | ❌ push subminor (bug) | ✅ skip subminor |
| `push` (version tag) | handled by semver rules | handled by semver rules |
