### PR TITLE
fix: prevent semver tags on scheduled (nightly) builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -214,11 +214,11 @@ jobs:
             type=raw,value=${{ steps.version.outputs.major }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
             type=raw,value=${{ steps.version.outputs.major_minor }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
             # Semantic version tags from git tags (v1.0.0 -> 1.0.0, 1.0, 1)
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-') }}
+            type=semver,pattern={{version}},enable=${{ github.event_name != 'schedule' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name != 'schedule' }}
+            type=semver,pattern={{major}},enable=${{ github.event_name != 'schedule' && !contains(github.ref, '-') }}
             # Pre-release tags (alpha, beta, rc) - tag with full version only
-            type=semver,pattern={{version}},enable=${{ contains(github.ref, '-') }}
+            type=semver,pattern={{version}},enable=${{ github.event_name != 'schedule' && contains(github.ref, '-') }}
             # Tag with the git ref (for manual identification)
             type=ref,event=tag
       

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -210,9 +210,9 @@ jobs:
             # Tag with commit SHA
             type=sha,prefix=,format=short
             # Exact version and floating major/minor tags for main or schedule
-            type=raw,value=${{ steps.version.outputs.version }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-            type=raw,value=${{ steps.version.outputs.major }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-            type=raw,value=${{ steps.version.outputs.major_minor }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+            type=raw,value=${{ steps.version.outputs.version }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch' }}
+            type=raw,value=${{ steps.version.outputs.major }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch' }}
+            type=raw,value=${{ steps.version.outputs.major_minor }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch' }}
             # Semantic version tags from git tags (v1.0.0 -> 1.0.0, 1.0, 1)
             type=semver,pattern={{version}},enable=${{ github.event_name != 'schedule' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name != 'schedule' }}


### PR DESCRIPTION
This PR ensures that nightly (schedule) builds only receive the tags: latest, short SHA, major, major.minor. The full semver tags (e.g. 2.0.10, 2.0, 2) are omitted to avoid polluting the nightly image stream.