### PR TITLE
fix: exclude full version tag and semver tags from scheduled (nightly) builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -213,12 +213,12 @@ jobs:
             type=raw,value=${{ steps.version.outputs.version }},enable=${{ github.event_name == 'workflow_run' || github.event_name == 'workflow_dispatch' }}
             type=raw,value=${{ steps.version.outputs.major }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
             type=raw,value=${{ steps.version.outputs.major_minor }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-            # Semantic version tags from git tags (v1.0.0 -> 1.0.0, 1.0, 1)
+            # Semantic version tags from git tags:
+            # - Stable releases (v1.0.0) -> 1.0.0, 1.0, 1
+            # - Pre-releases (v1.0.0-rc.1) -> 1.0.0-rc.1 only
             type=semver,pattern={{version}},enable=${{ github.event_name != 'schedule' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name != 'schedule' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name != 'schedule' && !contains(github.ref, '-') }}
             type=semver,pattern={{major}},enable=${{ github.event_name != 'schedule' && !contains(github.ref, '-') }}
-            # Pre-release tags (alpha, beta, rc) - tag with full version only
-            type=semver,pattern={{version}},enable=${{ github.event_name != 'schedule' && contains(github.ref, '-') }}
             # Tag with the git ref (for manual identification)
             type=ref,event=tag
       

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -214,11 +214,11 @@ jobs:
             type=raw,value=${{ steps.version.outputs.major }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
             type=raw,value=${{ steps.version.outputs.major_minor }},enable=${{ (github.ref_type == 'branch' && github.ref_name == 'main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
             # Semantic version tags from git tags (v1.0.0 -> 1.0.0, 1.0, 1)
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-') }}
+            type=semver,pattern={{version}},enable=${{ github.event_name != 'schedule' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name != 'schedule' }}
+            type=semver,pattern={{major}},enable=${{ github.event_name != 'schedule' && !contains(github.ref, '-') }}
             # Pre-release tags (alpha, beta, rc) - tag with full version only
-            type=semver,pattern={{version}},enable=${{ contains(github.ref, '-') }}
+            type=semver,pattern={{version}},enable=${{ github.event_name != 'schedule' && contains(github.ref, '-') }}
             # Tag with the git ref (for manual identification)
             type=ref,event=tag
       


### PR DESCRIPTION
This PR ensures that scheduled (nightly) Docker builds only receive: latest, short SHA, major, and major.minor. The full version (x.y.z) and semver‑style floating tags are omitted from nightly builds, while they remain available for pushes to main, manual workflow_dispatch, and git tag pushes.