### PR TITLE
chore(release): bump version to 2.0.13

### DIFF
--- a/.github/workflows/e2e-mcp-gateway.yml
+++ b/.github/workflows/e2e-mcp-gateway.yml
@@ -57,8 +57,8 @@ jobs:
 
       - name: Build docker-mcp plugin from source
         run: |
-          # Clone the MCP Gateway repo
-          git clone --depth 1 https://github.com/docker/mcp-gateway.git /tmp/mcp-gateway
+          # Clone the MCP Gateway repo (pinned to v0.41.0 — matches local Docker Desktop version)
+          git clone --depth 1 --branch v0.41.0 https://github.com/docker/mcp-gateway.git /tmp/mcp-gateway
           cd /tmp/mcp-gateway
           
           # Build the plugin

--- a/.github/workflows/e2e-mcp-gateway.yml
+++ b/.github/workflows/e2e-mcp-gateway.yml
@@ -57,8 +57,8 @@ jobs:
 
       - name: Build docker-mcp plugin from source
         run: |
-          # Clone the MCP Gateway repo (pinned to v0.41.0 — matches local Docker Desktop version)
-          git clone --depth 1 --branch v0.41.0 https://github.com/docker/mcp-gateway.git /tmp/mcp-gateway
+          # Clone the MCP Gateway repo at latest HEAD
+          git clone --depth 1 https://github.com/docker/mcp-gateway.git /tmp/mcp-gateway
           cd /tmp/mcp-gateway
           
           # Build the plugin

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -9,18 +9,15 @@ name: Weekly Maintenance
 #   3. Run formatters (isort, black, ruff) + unit tests locally
 #   4. Push a release branch and open a PR
 #   5. Wait up to 90 min for all CI checks to pass
-#   6. Scan Copilot review comments for critical keywords; block + alert if found
+#   6. Scan Copilot review comments for critical keywords; block + open issue if found
 #   7. Auto-merge the PR
 #   8. Create the formal GitHub release (tag + generated notes)
-#   9. Notify Dave on Slack with the outcome
 #
 # What is NOT automated (requires human judgment):
 #   - Evaluating non-critical Copilot review suggestions or acting on them
 #   - Deciding whether a breaking API change from a dependency is acceptable
 #
-# Required secrets:
-#   SLACK_WEBHOOK_URL  – Incoming webhook URL for the target Slack workspace
-#                        (if absent, workflow skips Slack and logs the message)
+# Failures produce a GitHub Actions email automatically.
 # ─────────────────────────────────────────────────────────────────────────────
 
 on:
@@ -495,49 +492,3 @@ jobs:
 
           echo "✅ Release $TAG created — Docker images will build automatically"
 
-
-  # ───────────────────────────────────────────────────────────────────────────
-  # Job 7 – Notify Dave on Slack for success outcomes only.
-  # Failures/blocks send a GitHub Actions email automatically — no Slack needed.
-  # ───────────────────────────────────────────────────────────────────────────
-  notify:
-    name: Slack Notification
-    needs: [check, prepare, wait-checks, review, merge, release]
-    if: always()
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Send Slack notification (success cases only)
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          HAS_CHANGES:    ${{ needs.check.outputs.has_changes }}
-          MERGE_RESULT:   ${{ needs.merge.result }}
-          RELEASE_RESULT: ${{ needs.release.result }}
-          NEW_VERSION:    ${{ needs.prepare.outputs.new_version }}
-          PR_NUMBER:      ${{ needs.prepare.outputs.pr_number }}
-          REPO:           ${{ github.repository }}
-        run: |
-          # Only notify on the two happy paths; all failure modes produce a
-          # GitHub Actions email already so there is no need to duplicate them.
-          if [ "$HAS_CHANGES" = "false" ]; then
-            MSG="no updates needed this week — nothing to release"
-          elif [ "$MERGE_RESULT" = "success" ] && [ "$RELEASE_RESULT" = "success" ]; then
-            MSG="v${NEW_VERSION} released! PR #${PR_NUMBER} merged, GitHub release created, Docker images building. https://github.com/${REPO}/releases/tag/v${NEW_VERSION}"
-          else
-            echo "Non-success outcome — skipping Slack (email already sent by GitHub Actions)"
-            exit 0
-          fi
-
-          if [ -z "$SLACK_WEBHOOK_URL" ]; then
-            echo "SLACK_WEBHOOK_URL not configured — would have sent: nextdns-mcp: ${MSG}"
-            exit 0
-          fi
-
-          # Pass message via env var and use python -c one-liner to avoid JSON quoting issues
-          SLACK_MSG="nextdns-mcp: ${MSG}" python3 -c "
-          import json, os, urllib.request
-          m = os.environ['SLACK_MSG']
-          w = os.environ['SLACK_WEBHOOK_URL']
-          urllib.request.urlopen(urllib.request.Request(w, data=json.dumps({'text': m}).encode(), headers={'Content-Type': 'application/json'}))
-          print('Slack notification sent')
-          "

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -26,9 +26,7 @@ on:
   workflow_dispatch:      # Allow manual trigger for testing
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 # Prevent parallel weekly runs from racing each other
 concurrency:
@@ -122,6 +120,9 @@ jobs:
     needs: check
     if: needs.check.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       new_version: ${{ steps.bump.outputs.new_version }}
       branch_name: ${{ steps.bump.outputs.branch_name }}
@@ -215,7 +216,7 @@ jobs:
           git push origin ":${BRANCH}" 2>/dev/null || true
 
           git checkout -b "$BRANCH"
-          git add pyproject.toml src/nextdns_mcp/__init__.py Dockerfile uv.lock
+          git add -A
 
           # Build commit message without literal newlines in the YAML block
           printf '%s\n\n%s\n' \
@@ -301,8 +302,9 @@ jobs:
 
             TOTAL=$(   echo "$CHECKS_JSON" | jq 'length')
             COMPLETE=$(echo "$CHECKS_JSON" | jq '[.[] | select(.status == "completed")] | length')
-            SUCCESS=$( echo "$CHECKS_JSON" | jq '[.[] | select(.conclusion == "success")] | length')
-            FAILED=$(  echo "$CHECKS_JSON" | jq '[.[] | select(.conclusion | . == "failure" or . == "cancelled" or . == "timed_out")] | length')
+            # skipped/neutral/stale are acceptable — only count genuinely successful runs
+            SUCCESS=$( echo "$CHECKS_JSON" | jq '[.[] | select(.conclusion == "success" or .conclusion == "skipped" or .conclusion == "neutral")] | length')
+            FAILED=$(  echo "$CHECKS_JSON" | jq '[.[] | select(.conclusion | . == "failure" or . == "cancelled" or . == "timed_out" or . == "action_required")] | length')
 
             echo "Attempt $ATTEMPT/$MAX_ATTEMPTS — $COMPLETE/$TOTAL complete | $SUCCESS success | $FAILED failed"
 
@@ -338,6 +340,9 @@ jobs:
     needs: [prepare, wait-checks]
     if: needs.wait-checks.outputs.checks_passed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      issues: write
     outputs:
       safe_to_merge: ${{ steps.inspect.outputs.safe_to_merge }}
       block_reason:  ${{ steps.inspect.outputs.block_reason }}
@@ -427,6 +432,9 @@ jobs:
     needs: [prepare, wait-checks, review]
     if: needs.review.outputs.safe_to_merge == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Enable auto-merge and wait for completion
@@ -463,6 +471,8 @@ jobs:
     needs: [prepare, merge]
     if: needs.merge.result == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout main

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -218,10 +218,9 @@ jobs:
           git add pyproject.toml src/nextdns_mcp/__init__.py Dockerfile uv.lock
 
           # Build commit message without literal newlines in the YAML block
-          printf '%s\n\n%s\n\n%s\n' \
+          printf '%s\n\n%s\n' \
             "chore: weekly maintenance — bump to v${NEW_VERSION}" \
             "Changes: ${CHANGES}" \
-            "Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>" \
             > /tmp/commit_msg.txt
           git commit -F /tmp/commit_msg.txt
           git push origin "$BRANCH"

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -1,0 +1,598 @@
+name: Weekly Maintenance
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Automated weekly maintenance: dependency updates, version bump, PR, release.
+#
+# What this automates:
+#   1. Detect unreleased commits OR dependency updates (uv lock --upgrade)
+#   2. Bump the patch version across pyproject.toml / __init__.py / Dockerfile
+#   3. Run formatters (isort, black, ruff) + unit tests locally
+#   4. Push a release branch and open a PR
+#   5. Wait up to 90 min for all CI checks to pass
+#   6. Scan Copilot review comments for critical keywords; block + alert if found
+#   7. Auto-merge the PR
+#   8. Create the formal GitHub release (tag + generated notes)
+#   9. Notify Dave on Slack with the outcome
+#
+# What is NOT automated (requires human judgment):
+#   - Evaluating non-critical Copilot review suggestions or acting on them
+#   - Deciding whether a breaking API change from a dependency is acceptable
+#
+# Required secrets:
+#   SLACK_WEBHOOK_URL  – Incoming webhook URL for the target Slack workspace
+#                        (if absent, workflow skips Slack and logs the message)
+# ─────────────────────────────────────────────────────────────────────────────
+
+on:
+  schedule:
+    - cron: '0 7 * * 0'  # Sunday 07:00 UTC = 02:00 EST / 03:00 EDT
+  workflow_dispatch:      # Allow manual trigger for testing
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+# Prevent parallel weekly runs from racing each other
+concurrency:
+  group: weekly-maintenance
+  cancel-in-progress: false
+
+jobs:
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Job 1 – Detect whether anything needs to be released
+  # ───────────────────────────────────────────────────────────────────────────
+  check:
+    name: Check for Changes
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes:      ${{ steps.detect.outputs.has_changes }}
+      deps_updated:     ${{ steps.detect.outputs.deps_updated }}
+      unreleased_count: ${{ steps.detect.outputs.unreleased_count }}
+      current_version:  ${{ steps.detect.outputs.current_version }}
+      changes_summary:  ${{ steps.detect.outputs.changes_summary }}
+
+    steps:
+      - name: Checkout (full history for tag comparison)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Detect changes
+        id: detect
+        run: |
+          set -euo pipefail
+
+          CURRENT_VERSION=$(python3 -c "
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              print(tomllib.load(f)['project']['version'])
+          ")
+          echo "current_version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+
+          # ── Dependency updates ──────────────────────────────────────────────
+          uv lock --upgrade
+          if git diff --quiet uv.lock; then
+            DEPS_UPDATED=false
+            echo "No dependency updates"
+          else
+            DEPS_UPDATED=true
+            echo "Dependency updates detected:"
+            git diff --stat uv.lock
+          fi
+          echo "deps_updated=$DEPS_UPDATED" >> "$GITHUB_OUTPUT"
+
+          # ── Unreleased commits ──────────────────────────────────────────────
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$LATEST_TAG" ]; then
+            UNRELEASED=$(git log "${LATEST_TAG}..HEAD" --oneline | wc -l | tr -d ' ')
+            echo "Unreleased commits since $LATEST_TAG: $UNRELEASED"
+          else
+            UNRELEASED=$(git log --oneline | wc -l | tr -d ' ')
+            echo "No tags found; treating all $UNRELEASED commits as unreleased"
+          fi
+          echo "unreleased_count=$UNRELEASED" >> "$GITHUB_OUTPUT"
+
+          # ── Final decision ──────────────────────────────────────────────────
+          if [ "$DEPS_UPDATED" = "true" ] || [ "$UNRELEASED" -gt 0 ]; then
+            HAS_CHANGES=true
+            if   [ "$DEPS_UPDATED" = "true" ] && [ "$UNRELEASED" -gt 0 ]; then
+              SUMMARY="dependency updates + $UNRELEASED unreleased commit(s)"
+            elif [ "$DEPS_UPDATED" = "true" ]; then
+              SUMMARY="dependency updates only"
+            else
+              SUMMARY="$UNRELEASED unreleased commit(s)"
+            fi
+          else
+            HAS_CHANGES=false
+            SUMMARY="no changes detected"
+          fi
+
+          echo "has_changes=$HAS_CHANGES"   >> "$GITHUB_OUTPUT"
+          echo "changes_summary=$SUMMARY"   >> "$GITHUB_OUTPUT"
+          echo "Result: has_changes=$HAS_CHANGES ($SUMMARY)"
+
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Job 2 – Bump version, run quality checks, push branch, open PR
+  # ───────────────────────────────────────────────────────────────────────────
+  prepare:
+    name: Prepare Release
+    needs: check
+    if: needs.check.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.bump.outputs.new_version }}
+      branch_name: ${{ steps.bump.outputs.branch_name }}
+      pr_number:   ${{ steps.open_pr.outputs.pr_number }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          activate-environment: "true"
+
+      - name: Set up Python
+        run: uv python install 3.14
+
+      - name: Bump patch version
+        id: bump
+        run: |
+          python3 << 'PY'
+          import re
+          import tomllib
+          from pathlib import Path
+
+          with open("pyproject.toml", "rb") as f:
+              v = tomllib.load(f)["project"]["version"]
+
+          major, minor, patch = map(int, v.split("."))
+          patch += 1
+          new_v = f"{major}.{minor}.{patch}"
+
+          UPDATES = [
+              ("pyproject.toml",
+               r'^version\s*=\s*"[^"]*"',
+               f'version = "{new_v}"',
+               re.MULTILINE),
+              ("src/nextdns_mcp/__init__.py",
+               r'__version__\s*=\s*["\'][^"\']*["\']',
+               f'__version__ = "{new_v}"',
+               0),
+              ("Dockerfile",
+               r'LABEL org\.opencontainers\.image\.version=["\'][^"\']*["\']',
+               f'LABEL org.opencontainers.image.version="{new_v}"',
+               0),
+          ]
+
+          for path, pattern, replacement, flags in UPDATES:
+              p = Path(path)
+              old = p.read_text()
+              new = re.sub(pattern, replacement, old, flags=flags)
+              p.write_text(new)
+              status = "✅" if old != new else "⚠️  (no change)"
+              print(f"{status} {path}")
+
+          Path("new_version.txt").write_text(new_v)
+          print(f"\nBumped {v} → {new_v}")
+          PY
+
+          NEW_VERSION=$(cat new_version.txt)
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch_name=release/v${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Upgrade dependencies
+        run: uv lock --upgrade
+
+      - name: Install all extras
+        run: uv sync --all-extras
+
+      - name: Run formatters
+        run: |
+          uv run isort src/ tests/
+          uv run black src/ tests/
+          uv run ruff check --fix .
+
+      - name: Run unit tests
+        run: uv run pytest tests/unit --cov=src/nextdns_mcp --cov-report=term-missing
+
+      - name: Push release branch
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          CHANGES: ${{ needs.check.outputs.changes_summary }}
+        run: |
+          BRANCH="${{ steps.bump.outputs.branch_name }}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Clean up any stale remote branch from a previous failed run
+          git push origin ":${BRANCH}" 2>/dev/null || true
+
+          git checkout -b "$BRANCH"
+          git add pyproject.toml src/nextdns_mcp/__init__.py Dockerfile uv.lock
+
+          # Build commit message without literal newlines in the YAML block
+          printf '%s\n\n%s\n\n%s\n' \
+            "chore: weekly maintenance — bump to v${NEW_VERSION}" \
+            "Changes: ${CHANGES}" \
+            "Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>" \
+            > /tmp/commit_msg.txt
+          git commit -F /tmp/commit_msg.txt
+          git push origin "$BRANCH"
+
+      - name: Open pull request
+        id: open_pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          CURRENT_VERSION: ${{ needs.check.outputs.current_version }}
+          CHANGES: ${{ needs.check.outputs.changes_summary }}
+        run: |
+          BRANCH="${{ steps.bump.outputs.branch_name }}"
+
+          # Close any stale open PR for this branch before creating a new one
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Closing stale PR #$EXISTING_PR"
+            gh pr close "$EXISTING_PR" --comment "Superseded by a new weekly maintenance run." 2>/dev/null || true
+          fi
+
+          # Build PR body using printf (avoids heredoc/multi-line-string YAML issues)
+          printf '## Weekly Automated Maintenance\n\n**Trigger:** %s\n**Version bump:** `%s` \u2192 `%s`\n\n### What was done\n- Ran `uv lock --upgrade` to update dependencies\n- Bumped patch version to `%s`\n- Applied formatters (isort, black, ruff)\n- All unit tests passed locally\n\n---\n*Auto-created by the [weekly maintenance workflow](../actions/workflows/weekly-maintenance.yml). Will auto-merge once CI is green and no critical review issues are detected.*\n' \
+            "${CHANGES}" "${CURRENT_VERSION}" "${NEW_VERSION}" "${NEW_VERSION}" \
+            > /tmp/pr_body.md
+
+          PR_URL=$(gh pr create \
+            --title "chore: weekly maintenance — v${CURRENT_VERSION} -> v${NEW_VERSION}" \
+            --body-file /tmp/pr_body.md \
+            --base main \
+            --head "$BRANCH")
+
+          PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "Opened PR #$PR_NUMBER: $PR_URL"
+
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Job 3 – Poll CI checks on the PR (unit tests + E2E) — up to 90 minutes
+  # ───────────────────────────────────────────────────────────────────────────
+  wait-checks:
+    name: Wait for PR Checks
+    needs: [check, prepare]
+    if: needs.prepare.result == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      checks_passed: ${{ steps.poll.outputs.checks_passed }}
+
+    steps:
+      - name: Poll checks (max 90 min)
+        id: poll
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ needs.prepare.outputs.pr_number }}"
+          MAX_ATTEMPTS=90   # 90 × 60s = 90 minutes
+          ATTEMPT=0
+
+          echo "Polling checks for PR #$PR_NUMBER (max ${MAX_ATTEMPTS} min)..."
+
+          # Give GitHub Actions a moment to queue the triggered workflows
+          sleep 60
+
+          while [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; do
+            ATTEMPT=$((ATTEMPT + 1))
+
+            HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid' 2>/dev/null || echo "")
+            if [ -z "$HEAD_SHA" ]; then
+              echo "Could not resolve HEAD SHA — retrying..."
+              sleep 60
+              continue
+            fi
+
+            # Fetch all check runs for the head commit (up to 100)
+            CHECKS_JSON=$(gh api \
+              "repos/${{ github.repository }}/commits/${HEAD_SHA}/check-runs?per_page=100" \
+              --jq '[.check_runs[] | {name, status, conclusion}]' 2>/dev/null || echo "[]")
+
+            TOTAL=$(   echo "$CHECKS_JSON" | jq 'length')
+            COMPLETE=$(echo "$CHECKS_JSON" | jq '[.[] | select(.status == "completed")] | length')
+            SUCCESS=$( echo "$CHECKS_JSON" | jq '[.[] | select(.conclusion == "success")] | length')
+            FAILED=$(  echo "$CHECKS_JSON" | jq '[.[] | select(.conclusion | . == "failure" or . == "cancelled" or . == "timed_out")] | length')
+
+            echo "Attempt $ATTEMPT/$MAX_ATTEMPTS — $COMPLETE/$TOTAL complete | $SUCCESS success | $FAILED failed"
+
+            if [ "$FAILED" -gt 0 ]; then
+              echo "❌ $FAILED check(s) failed:"
+              echo "$CHECKS_JSON" | jq -r '.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out") | "  • \(.name): \(.conclusion)"'
+              echo "checks_passed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            if [ "$TOTAL" -gt 0 ] && [ "$COMPLETE" -eq "$TOTAL" ] && [ "$SUCCESS" -eq "$TOTAL" ]; then
+              echo "✅ All $TOTAL check(s) passed"
+              echo "checks_passed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            sleep 60
+          done
+
+          echo "⏰ Timed out after ${MAX_ATTEMPTS} minutes waiting for checks"
+          echo "checks_passed=false" >> "$GITHUB_OUTPUT"
+
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Job 4 – Inspect Copilot review comments for critical keywords
+  #
+  # NOTE: Full AI evaluation of suggestions is not feasible in GitHub Actions.
+  # This job uses keyword matching for security/breaking-change signals.
+  # Non-critical Copilot suggestions (style, refactoring, etc.) are ignored.
+  # ───────────────────────────────────────────────────────────────────────────
+  review:
+    name: Review Copilot Comments
+    needs: [prepare, wait-checks]
+    if: needs.wait-checks.outputs.checks_passed == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      safe_to_merge: ${{ steps.inspect.outputs.safe_to_merge }}
+      block_reason:  ${{ steps.inspect.outputs.block_reason }}
+
+    steps:
+      - name: Scan for critical Copilot feedback
+        id: inspect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ needs.prepare.outputs.pr_number }}"
+          REPO="${{ github.repository }}"
+
+          # Collect all Copilot review bodies + inline comment bodies
+          REVIEW_BODIES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            --jq '[.[] | select(.user.login | ascii_downcase | startswith("copilot")) | .body] | join("\n")' \
+            2>/dev/null || echo "")
+
+          INLINE_BODIES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+            --jq '[.[] | select(.user.login | ascii_downcase | startswith("copilot")) | .body] | join("\n")' \
+            2>/dev/null || echo "")
+
+          ALL="${REVIEW_BODIES}
+          ${INLINE_BODIES}"
+
+          if [ -z "$(echo "$ALL" | tr -d '[:space:]')" ]; then
+            echo "No Copilot review comments found — safe to merge"
+            echo "safe_to_merge=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Copilot comments found. Scanning for critical keywords..."
+          echo "--- BEGIN COMMENTS ---"
+          echo "$ALL"
+          echo "--- END COMMENTS ---"
+
+          # Keywords that warrant stopping and alerting a human
+          CRITICAL_RE='vulnerability|CVE-[0-9]|exploit|injection|overflow|RCE|XSS|CSRF|SSRF|path traversal|unsafe|breaking.change|breaking-change|security risk'
+
+          if MATCH=$(echo "$ALL" | grep -iEo "$CRITICAL_RE" | head -1 2>/dev/null); then
+            echo "⚠️  Critical keyword detected: '$MATCH'"
+            echo "safe_to_merge=false" >> "$GITHUB_OUTPUT"
+            echo "block_reason=Copilot flagged keyword: $MATCH" >> "$GITHUB_OUTPUT"
+          else
+            echo "✅ No critical keywords detected — safe to merge"
+            echo "safe_to_merge=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open blocking issue for critical Copilot feedback
+        if: steps.inspect.outputs.safe_to_merge == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Try with labels first; fall back without if labels don't exist
+          gh issue create \
+            --title "⚠️ Weekly maintenance PR #${{ needs.prepare.outputs.pr_number }} blocked — critical Copilot review" \
+            --body "The weekly maintenance workflow detected a potentially critical issue in Copilot's review of PR #${{ needs.prepare.outputs.pr_number }}.
+
+          **Reason:** ${{ steps.inspect.outputs.block_reason }}
+
+          **PR:** https://github.com/${{ github.repository }}/pull/${{ needs.prepare.outputs.pr_number }}
+
+          **Action required:** Please review the PR manually and either merge it yourself or close it.
+
+          ---
+          *Opened automatically by the [weekly maintenance workflow](../actions/workflows/weekly-maintenance.yml).*" \
+            --label "security,needs-human-review" 2>/dev/null || \
+          gh issue create \
+            --title "⚠️ Weekly maintenance PR #${{ needs.prepare.outputs.pr_number }} blocked — critical Copilot review" \
+            --body "The weekly maintenance workflow detected a potentially critical issue in Copilot's review of PR #${{ needs.prepare.outputs.pr_number }}.
+
+          **Reason:** ${{ steps.inspect.outputs.block_reason }}
+
+          **PR:** https://github.com/${{ github.repository }}/pull/${{ needs.prepare.outputs.pr_number }}
+
+          **Action required:** Please review the PR manually and either merge it yourself or close it.
+
+          ---
+          *Opened automatically by the [weekly maintenance workflow](../actions/workflows/weekly-maintenance.yml).*"
+
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Job 5 – Merge the PR
+  # ───────────────────────────────────────────────────────────────────────────
+  merge:
+    name: Merge PR
+    needs: [prepare, wait-checks, review]
+    if: needs.review.outputs.safe_to_merge == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Enable auto-merge and wait for completion
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ needs.prepare.outputs.pr_number }}"
+          echo "Enabling auto-merge on PR #$PR_NUMBER..."
+
+          # --auto ensures merge fires even if branch-protection rules require a brief delay
+          gh pr merge "$PR_NUMBER" --merge --auto
+
+          echo "Waiting for merge to complete (max 10 min)..."
+          for i in $(seq 1 20); do
+            STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+            echo "Attempt $i/20 — state: $STATE"
+            if [ "$STATE" = "MERGED" ]; then
+              echo "✅ PR #$PR_NUMBER merged"
+              exit 0
+            fi
+            sleep 30
+          done
+
+          echo "❌ Timed out waiting for merge"
+          exit 1
+
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Job 6 – Create formal GitHub release (creates tag + generates release notes)
+  # docker-publish.yml will automatically pick up the new tag and push images.
+  # ───────────────────────────────────────────────────────────────────────────
+  release:
+    name: Create GitHub Release
+    needs: [prepare, merge]
+    if: needs.merge.result == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ needs.prepare.outputs.new_version }}"
+
+          # Idempotent: skip if the release already exists
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — skipping"
+            exit 0
+          fi
+
+          echo "Creating release $TAG..."
+          gh release create "$TAG" \
+            --generate-notes \
+            --title "$TAG" \
+            --target main
+
+          echo "✅ Release $TAG created — Docker images will build automatically"
+
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Job 7 – Notify Dave on Slack regardless of the overall outcome
+  # ───────────────────────────────────────────────────────────────────────────
+  notify:
+    name: Slack Notification
+    needs: [check, prepare, wait-checks, review, merge, release]
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Build notification message
+        id: msg
+        run: |
+          HAS_CHANGES="${{ needs.check.outputs.has_changes }}"
+          PREPARE_RESULT="${{ needs.prepare.result }}"
+          CHECKS_PASSED="${{ needs.wait-checks.outputs.checks_passed }}"
+          SAFE_TO_MERGE="${{ needs.review.outputs.safe_to_merge }}"
+          BLOCK_REASON="${{ needs.review.outputs.block_reason }}"
+          MERGE_RESULT="${{ needs.merge.result }}"
+          RELEASE_RESULT="${{ needs.release.result }}"
+          NEW_VERSION="${{ needs.prepare.outputs.new_version }}"
+          PR_NUMBER="${{ needs.prepare.outputs.pr_number }}"
+          REPO="${{ github.repository }}"
+          DAVE="<@U01AGRUAXNV>"
+
+          if [ "$HAS_CHANGES" = "false" ]; then
+            MSG="✅ *nextdns-mcp weekly maintenance* — no updates needed this week. Nothing to release."
+            MENTION=""
+
+          elif [ "$PREPARE_RESULT" != "success" ]; then
+            MSG="❌ *nextdns-mcp weekly maintenance* — preparation failed (version bump, formatters, or unit tests). Check: https://github.com/${REPO}/actions"
+            MENTION=" $DAVE"
+
+          elif [ "$CHECKS_PASSED" = "false" ]; then
+            MSG="❌ *nextdns-mcp weekly maintenance* — CI checks failed on PR #${PR_NUMBER} for v${NEW_VERSION}. Check: https://github.com/${REPO}/pull/${PR_NUMBER}"
+            MENTION=" $DAVE"
+
+          elif [ "$SAFE_TO_MERGE" = "false" ]; then
+            MSG="⚠️ *nextdns-mcp weekly maintenance* — PR #${PR_NUMBER} (v${NEW_VERSION}) *blocked by critical Copilot review*. ${BLOCK_REASON}. A GitHub issue has been opened. https://github.com/${REPO}/pull/${PR_NUMBER}"
+            MENTION=" $DAVE"
+
+          elif [ "$MERGE_RESULT" = "success" ] && [ "$RELEASE_RESULT" = "success" ]; then
+            MSG="✅ *nextdns-mcp weekly maintenance* — *v${NEW_VERSION}* released! PR #${PR_NUMBER} merged · GitHub release created · Docker images building. https://github.com/${REPO}/releases/tag/v${NEW_VERSION}"
+            MENTION=""
+
+          elif [ "$MERGE_RESULT" = "success" ]; then
+            MSG="⚠️ *nextdns-mcp weekly maintenance* — PR #${PR_NUMBER} merged but release creation failed for v${NEW_VERSION}. Check: https://github.com/${REPO}/actions"
+            MENTION=" $DAVE"
+
+          else
+            MSG="⚠️ *nextdns-mcp weekly maintenance* — unexpected outcome for v${NEW_VERSION}. merge=${MERGE_RESULT}, release=${RELEASE_RESULT}. Check: https://github.com/${REPO}/actions"
+            MENTION=" $DAVE"
+          fi
+
+          # Write as a single line (newlines would break the output variable)
+          FULL_MSG="${MSG}${MENTION}"
+          echo "message<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$FULL_MSG"    >> "$GITHUB_OUTPUT"
+          echo "EOF"          >> "$GITHUB_OUTPUT"
+
+      - name: Send Slack notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          MSG='${{ steps.msg.outputs.message }}'
+
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "⚠️  SLACK_WEBHOOK_URL secret not configured — notification skipped"
+            echo "Message that would have been sent:"
+            echo "$MSG"
+            exit 0
+          fi
+
+          # Use Python to build valid JSON (avoids quoting hell with special chars)
+          HTTP_CODE=$(python3 - << 'PY'
+          import json, os, sys, urllib.request
+
+          msg = os.environ.get("SLACK_MSG", "")
+          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
+
+          payload = json.dumps({"text": msg}).encode()
+          req = urllib.request.Request(webhook, data=payload,
+                                       headers={"Content-Type": "application/json"})
+          try:
+              with urllib.request.urlopen(req) as r:
+                  print(r.status)
+          except Exception as e:
+              print(f"0 ({e})", file=sys.stderr)
+              sys.exit(1)
+          PY
+          )
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "✅ Slack notification sent"
+          else
+            echo "⚠️  Slack returned HTTP $HTTP_CODE"
+          fi
+        env:
+          SLACK_MSG: ${{ steps.msg.outputs.message }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -497,7 +497,8 @@ jobs:
 
 
   # ───────────────────────────────────────────────────────────────────────────
-  # Job 7 – Notify Dave on Slack regardless of the overall outcome
+  # Job 7 – Notify Dave on Slack for success outcomes only.
+  # Failures/blocks send a GitHub Actions email automatically — no Slack needed.
   # ───────────────────────────────────────────────────────────────────────────
   notify:
     name: Slack Notification
@@ -506,93 +507,37 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Build notification message
-        id: msg
-        run: |
-          HAS_CHANGES="${{ needs.check.outputs.has_changes }}"
-          PREPARE_RESULT="${{ needs.prepare.result }}"
-          CHECKS_PASSED="${{ needs.wait-checks.outputs.checks_passed }}"
-          SAFE_TO_MERGE="${{ needs.review.outputs.safe_to_merge }}"
-          BLOCK_REASON="${{ needs.review.outputs.block_reason }}"
-          MERGE_RESULT="${{ needs.merge.result }}"
-          RELEASE_RESULT="${{ needs.release.result }}"
-          NEW_VERSION="${{ needs.prepare.outputs.new_version }}"
-          PR_NUMBER="${{ needs.prepare.outputs.pr_number }}"
-          REPO="${{ github.repository }}"
-          DAVE="<@U01AGRUAXNV>"
-
-          if [ "$HAS_CHANGES" = "false" ]; then
-            MSG="✅ *nextdns-mcp weekly maintenance* — no updates needed this week. Nothing to release."
-            MENTION=""
-
-          elif [ "$PREPARE_RESULT" != "success" ]; then
-            MSG="❌ *nextdns-mcp weekly maintenance* — preparation failed (version bump, formatters, or unit tests). Check: https://github.com/${REPO}/actions"
-            MENTION=" $DAVE"
-
-          elif [ "$CHECKS_PASSED" = "false" ]; then
-            MSG="❌ *nextdns-mcp weekly maintenance* — CI checks failed on PR #${PR_NUMBER} for v${NEW_VERSION}. Check: https://github.com/${REPO}/pull/${PR_NUMBER}"
-            MENTION=" $DAVE"
-
-          elif [ "$SAFE_TO_MERGE" = "false" ]; then
-            MSG="⚠️ *nextdns-mcp weekly maintenance* — PR #${PR_NUMBER} (v${NEW_VERSION}) *blocked by critical Copilot review*. ${BLOCK_REASON}. A GitHub issue has been opened. https://github.com/${REPO}/pull/${PR_NUMBER}"
-            MENTION=" $DAVE"
-
-          elif [ "$MERGE_RESULT" = "success" ] && [ "$RELEASE_RESULT" = "success" ]; then
-            MSG="✅ *nextdns-mcp weekly maintenance* — *v${NEW_VERSION}* released! PR #${PR_NUMBER} merged · GitHub release created · Docker images building. https://github.com/${REPO}/releases/tag/v${NEW_VERSION}"
-            MENTION=""
-
-          elif [ "$MERGE_RESULT" = "success" ]; then
-            MSG="⚠️ *nextdns-mcp weekly maintenance* — PR #${PR_NUMBER} merged but release creation failed for v${NEW_VERSION}. Check: https://github.com/${REPO}/actions"
-            MENTION=" $DAVE"
-
-          else
-            MSG="⚠️ *nextdns-mcp weekly maintenance* — unexpected outcome for v${NEW_VERSION}. merge=${MERGE_RESULT}, release=${RELEASE_RESULT}. Check: https://github.com/${REPO}/actions"
-            MENTION=" $DAVE"
-          fi
-
-          # Write as a single line (newlines would break the output variable)
-          FULL_MSG="${MSG}${MENTION}"
-          echo "message<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$FULL_MSG"    >> "$GITHUB_OUTPUT"
-          echo "EOF"          >> "$GITHUB_OUTPUT"
-
-      - name: Send Slack notification
+      - name: Send Slack notification (success cases only)
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          HAS_CHANGES:    ${{ needs.check.outputs.has_changes }}
+          MERGE_RESULT:   ${{ needs.merge.result }}
+          RELEASE_RESULT: ${{ needs.release.result }}
+          NEW_VERSION:    ${{ needs.prepare.outputs.new_version }}
+          PR_NUMBER:      ${{ needs.prepare.outputs.pr_number }}
+          REPO:           ${{ github.repository }}
         run: |
-          MSG='${{ steps.msg.outputs.message }}'
-
-          if [ -z "$SLACK_WEBHOOK_URL" ]; then
-            echo "⚠️  SLACK_WEBHOOK_URL secret not configured — notification skipped"
-            echo "Message that would have been sent:"
-            echo "$MSG"
+          # Only notify on the two happy paths; all failure modes produce a
+          # GitHub Actions email already so there is no need to duplicate them.
+          if [ "$HAS_CHANGES" = "false" ]; then
+            MSG="no updates needed this week — nothing to release"
+          elif [ "$MERGE_RESULT" = "success" ] && [ "$RELEASE_RESULT" = "success" ]; then
+            MSG="v${NEW_VERSION} released! PR #${PR_NUMBER} merged, GitHub release created, Docker images building. https://github.com/${REPO}/releases/tag/v${NEW_VERSION}"
+          else
+            echo "Non-success outcome — skipping Slack (email already sent by GitHub Actions)"
             exit 0
           fi
 
-          # Use Python to build valid JSON (avoids quoting hell with special chars)
-          HTTP_CODE=$(python3 - << 'PY'
-          import json, os, sys, urllib.request
-
-          msg = os.environ.get("SLACK_MSG", "")
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-
-          payload = json.dumps({"text": msg}).encode()
-          req = urllib.request.Request(webhook, data=payload,
-                                       headers={"Content-Type": "application/json"})
-          try:
-              with urllib.request.urlopen(req) as r:
-                  print(r.status)
-          except Exception as e:
-              print(f"0 ({e})", file=sys.stderr)
-              sys.exit(1)
-          PY
-          )
-
-          if [ "$HTTP_CODE" = "200" ]; then
-            echo "✅ Slack notification sent"
-          else
-            echo "⚠️  Slack returned HTTP $HTTP_CODE"
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL not configured — would have sent: nextdns-mcp: ${MSG}"
+            exit 0
           fi
-        env:
-          SLACK_MSG: ${{ steps.msg.outputs.message }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+          # Pass message via env var and use python -c one-liner to avoid JSON quoting issues
+          SLACK_MSG="nextdns-mcp: ${MSG}" python3 -c "
+          import json, os, urllib.request
+          m = os.environ['SLACK_MSG']
+          w = os.environ['SLACK_WEBHOOK_URL']
+          urllib.request.urlopen(urllib.request.Request(w, data=json.dumps({'text': m}).encode(), headers={'Content-Type': 'application/json'}))
+          print('Slack notification sent')
+          "

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -444,8 +444,9 @@ jobs:
           PR_NUMBER="${{ needs.prepare.outputs.pr_number }}"
           echo "Enabling auto-merge on PR #$PR_NUMBER..."
 
-          # --auto ensures merge fires even if branch-protection rules require a brief delay
-          gh pr merge "$PR_NUMBER" --merge --auto
+          # Direct merge — no --auto needed because wait-checks already confirmed CI is green,
+          # and github-actions[bot] is configured as a branch-protection bypass actor.
+          gh pr merge "$PR_NUMBER" --merge
 
           echo "Waiting for merge to complete (max 10 min)..."
           for i in $(seq 1 20); do

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ LABEL org.opencontainers.image.description="Model Context Protocol server for Ne
 LABEL org.opencontainers.image.authors="NextDNS MCP Contributors"
 LABEL org.opencontainers.image.source="https://github.com/dmeiser/nextdns-mcp"
 LABEL org.opencontainers.image.documentation="https://github.com/dmeiser/nextdns-mcp/blob/main/README.md"
-LABEL org.opencontainers.image.version="2.0.12"
+LABEL org.opencontainers.image.version="2.0.13"
 LABEL org.opencontainers.image.licenses="MIT"
 
 # MCP-specific labels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nextdns-mcp"
-version = "2.0.12"
+version = "2.0.13"
 description = "NextDNS MCP Server - Model Context Protocol server for NextDNS API built with FastMCP"
 authors = [{name = "NextDNS MCP Contributors"}]
 license = {text = "MIT"}

--- a/scripts/gateway_e2e_run.sh
+++ b/scripts/gateway_e2e_run.sh
@@ -274,9 +274,8 @@ EOF
         log_success "Environment variables configured"
         rm -f "${ARTIFACTS_DIR}/config-temp.yaml"
     else
-        log_error "Failed to configure environment variables"
+        log_warn "docker mcp config write unavailable — using catalog defaults for env vars"
         rm -f "${ARTIFACTS_DIR}/config-temp.yaml"
-        exit 1
     fi
 else
     log_success "CI mode - all configuration in catalog"

--- a/scripts/gateway_e2e_run.sh
+++ b/scripts/gateway_e2e_run.sh
@@ -112,7 +112,7 @@ cleanup() {
             # If CI=true, or ALLOW_LIVE_WRITES is not "true", perform auto-delete (best-effort)
             if [ "${CI:-false}" = "true" ] || [ "${ALLOW_LIVE_WRITES}" != "true" ]; then
                 log_info "Auto-deleting validation profile (CI or non-writes mode)"
-                docker mcp tools call deleteProfile "profile_id=${VALIDATION_PROFILE}" \
+                docker mcp tools --gateway-arg="--catalog=${CATALOG_NAME}.yaml" --gateway-arg="--servers=${SERVER_NAME}" call deleteProfile "profile_id=${VALIDATION_PROFILE}" \
                     >/dev/null 2>&1 || log_warn "Failed to delete validation profile"
                 log_success "Validation profile deletion attempted"
             else
@@ -120,7 +120,7 @@ cleanup() {
                 echo
                 if [[ $REPLY = "yes" ]]; then
                     log_info "Deleting validation profile..."
-                    docker mcp tools call deleteProfile "profile_id=${VALIDATION_PROFILE}" \
+                    docker mcp tools --gateway-arg="--catalog=${CATALOG_NAME}.yaml" --gateway-arg="--servers=${SERVER_NAME}" call deleteProfile "profile_id=${VALIDATION_PROFILE}" \
                         >/dev/null 2>&1 || log_warn "Failed to delete validation profile"
                     log_success "Validation profile deleted"
                 else

--- a/scripts/gateway_e2e_run.sh
+++ b/scripts/gateway_e2e_run.sh
@@ -6,7 +6,7 @@
 # 1. Loads configuration from .env file
 # 2. Builds the Docker image
 # 3. Imports the catalog.yaml
-# 4. Enables the NextDNS server
+# 4. Configures gateway args for legacy catalog mode (replaces 'server enable')
 # 5. Configures API key secret
 # 6. Runs all tools via run_all_tools.sh
 # 7. Cleans up gateway configuration
@@ -282,16 +282,19 @@ else
     log_success "CI mode - all configuration in catalog"
 fi
 
-# Step 4: Enable server (AFTER config is set)
+# Step 4: Configure gateway args for legacy catalog mode (AFTER config is set)
+#
+# Note: Recent versions of docker-mcp always enable the profiles feature, which makes
+# 'docker mcp server enable' an obsolete command that exits with an error.  We bypass
+# the profiles system by passing --catalog / --servers gateway args to every tool call,
+# which forces the gateway into legacy catalog mode regardless of the profiles setting.
 log_info ""
-log_info "Step 4: Enabling server..."
+log_info "Step 4: Configuring server..."
 
-if docker mcp server enable nextdns >/dev/null 2>&1; then
-    log_success "Server enabled"
-else
-    log_error "Failed to enable server"
-    exit 1
-fi
+CATALOG_NAME="nextdns-mcp"
+SERVER_NAME="nextdns"
+export NEXTDNS_GATEWAY_ARGS="--catalog=${CATALOG_NAME}.yaml --servers=${SERVER_NAME}"
+log_success "Server configured (catalog: ${CATALOG_NAME}, server: ${SERVER_NAME})"
 
 # Debug: Show API key length (not the actual key)
 log_info "API key length: ${#NEXTDNS_API_KEY} characters"
@@ -324,7 +327,7 @@ log_info "Step 5: Waiting for server readiness..."
 MAX_ATTEMPTS=30
 ATTEMPT=0
 while [ ${ATTEMPT} -lt ${MAX_ATTEMPTS} ]; do
-    if docker mcp tools ls >/dev/null 2>&1; then
+    if docker mcp tools --gateway-arg="--catalog=${CATALOG_NAME}.yaml" --gateway-arg="--servers=${SERVER_NAME}" ls >/dev/null 2>&1; then
         log_success "Server is ready"
         break
     fi

--- a/scripts/gateway_e2e_run.sh
+++ b/scripts/gateway_e2e_run.sh
@@ -53,6 +53,7 @@ ENV_FILE="${1:-}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "${SCRIPT_DIR}")"
 ARTIFACTS_DIR="${PROJECT_DIR}/artifacts"
+TEMP_CATALOG=""  # Initialized early so cleanup can safely reference it
 
 # Load environment file
 if [ -z "${ENV_FILE}" ]; then
@@ -112,7 +113,7 @@ cleanup() {
             # If CI=true, or ALLOW_LIVE_WRITES is not "true", perform auto-delete (best-effort)
             if [ "${CI:-false}" = "true" ] || [ "${ALLOW_LIVE_WRITES}" != "true" ]; then
                 log_info "Auto-deleting validation profile (CI or non-writes mode)"
-                docker mcp tools --gateway-arg="--catalog=${CATALOG_NAME}.yaml" --gateway-arg="--servers=${SERVER_NAME}" call deleteProfile "profile_id=${VALIDATION_PROFILE}" \
+                docker mcp tools --gateway-arg="--catalog=${TEMP_CATALOG:-${CATALOG_NAME:-nextdns-mcp}.yaml}" --gateway-arg="--servers=${SERVER_NAME:-nextdns}" call deleteProfile "profile_id=${VALIDATION_PROFILE}" \
                     >/dev/null 2>&1 || log_warn "Failed to delete validation profile"
                 log_success "Validation profile deletion attempted"
             else
@@ -120,7 +121,7 @@ cleanup() {
                 echo
                 if [[ $REPLY = "yes" ]]; then
                     log_info "Deleting validation profile..."
-                    docker mcp tools --gateway-arg="--catalog=${CATALOG_NAME}.yaml" --gateway-arg="--servers=${SERVER_NAME}" call deleteProfile "profile_id=${VALIDATION_PROFILE}" \
+                    docker mcp tools --gateway-arg="--catalog=${TEMP_CATALOG:-${CATALOG_NAME:-nextdns-mcp}.yaml}" --gateway-arg="--servers=${SERVER_NAME:-nextdns}" call deleteProfile "profile_id=${VALIDATION_PROFILE}" \
                         >/dev/null 2>&1 || log_warn "Failed to delete validation profile"
                     log_success "Validation profile deleted"
                 else
@@ -129,6 +130,11 @@ cleanup() {
             fi
         
         rm -f "${ARTIFACTS_DIR}/validation_profile_id.txt"
+    fi
+    
+    # Cleanup injected catalog temp file (after profile deletion which may use gateway)
+    if [ -n "${TEMP_CATALOG}" ] && [ -f "${TEMP_CATALOG}" ]; then
+        rm -f "${TEMP_CATALOG}"
     fi
     
     log_success "Cleanup complete"
@@ -234,11 +240,10 @@ PY
     fi
 fi
 
-# Import catalog
+# Import catalog (also keeps the injected file available for direct-path gateway access)
 log_info "Importing catalog..."
 if docker mcp catalog import "${TEMP_CATALOG}" >/dev/null 2>&1; then
     log_success "Catalog imported"
-    rm -f "${TEMP_CATALOG}"
 else
     log_error "Failed to import catalog"
     rm -f "${TEMP_CATALOG}"
@@ -297,7 +302,9 @@ log_info "Step 4: Configuring server..."
 
 CATALOG_NAME="nextdns-mcp"
 SERVER_NAME="nextdns"
-export NEXTDNS_GATEWAY_ARGS="--catalog=${CATALOG_NAME}.yaml --servers=${SERVER_NAME}"
+# Use the absolute path of the injected catalog file so the gateway reads it directly
+# (bypasses ~/.docker/mcp/catalogs/ lookup which can fail silently in CI environments)
+export NEXTDNS_GATEWAY_ARGS="--catalog=${TEMP_CATALOG} --servers=${SERVER_NAME}"
 log_success "Server configured (catalog: ${CATALOG_NAME}, server: ${SERVER_NAME})"
 
 # Debug: Show API key length (not the actual key)
@@ -331,15 +338,19 @@ log_info "Step 5: Waiting for server readiness..."
 MAX_ATTEMPTS=30
 ATTEMPT=0
 while [ ${ATTEMPT} -lt ${MAX_ATTEMPTS} ]; do
-    if docker mcp tools --gateway-arg="--catalog=${CATALOG_NAME}.yaml" --gateway-arg="--servers=${SERVER_NAME}" ls >/dev/null 2>&1; then
-        log_success "Server is ready"
+    TOOL_COUNT=$(docker mcp tools --gateway-arg="--catalog=${TEMP_CATALOG}" --gateway-arg="--servers=${SERVER_NAME}" ls 2>/dev/null | grep -c '^ - ' || true)
+    if [ "${TOOL_COUNT}" -gt 0 ]; then
+        log_success "Server is ready (${TOOL_COUNT} tools available)"
         break
     fi
     
     ATTEMPT=$((ATTEMPT + 1))
     if [ ${ATTEMPT} -ge ${MAX_ATTEMPTS} ]; then
-        log_error "Server readiness timeout"
-        log_error "Check logs: docker mcp logs"
+        log_error "Server readiness timeout — no tools found after ${MAX_ATTEMPTS} attempts"
+        log_error "Catalog: ${TEMP_CATALOG}"
+        log_error "Debug output:"
+        docker mcp tools --gateway-arg="--catalog=${TEMP_CATALOG}" --gateway-arg="--servers=${SERVER_NAME}" ls 2>&1 | head -20 >&2 || true
+        cat "${TEMP_CATALOG}" | head -30 >&2 || true
         exit 1
     fi
     

--- a/scripts/gateway_e2e_run.sh
+++ b/scripts/gateway_e2e_run.sh
@@ -217,6 +217,11 @@ else:
         },
     )
 
+# Strip secrets declarations so docker-mcp v0.42+ does not generate unresolvable
+# se:// fallback URIs when the Docker Desktop secrets engine is absent (CI/Linux).
+# The env: injection above is the sole source of NEXTDNS_API_KEY in this mode.
+nextdns.pop("secrets", None)
+
 with open(temp_catalog, "w", encoding="utf-8") as f:
     yaml.dump(catalog, f, default_flow_style=False, sort_keys=False)
 PY

--- a/scripts/run_all_tools.sh
+++ b/scripts/run_all_tools.sh
@@ -102,7 +102,7 @@ log_success "Docker MCP is responding"
 
 # Parse tool names - tools ls returns an array of tool objects
 # Filter out MCP Gateway built-in tools (mcp-*, code-*) - only test NextDNS tools
-mapfile -t ALL_TOOLS < <(mcp_tools ls --format json 2>/dev/null | jq -r '.[] | .name')
+mapfile -t ALL_TOOLS < <(docker mcp tools --format json "${_MCP_GATEWAY_ARGS[@]}" ls 2>/dev/null | jq -r '.[] | .name')
 
 if [ ${#ALL_TOOLS[@]} -eq 0 ]; then
     log_error "No tools found"

--- a/scripts/run_all_tools.sh
+++ b/scripts/run_all_tools.sh
@@ -102,7 +102,7 @@ log_success "Docker MCP is responding"
 
 # Parse tool names - tools ls returns an array of tool objects
 # Filter out MCP Gateway built-in tools (mcp-*, code-*) - only test NextDNS tools
-mapfile -t ALL_TOOLS < <(mcp_tools ls --format json 2>&1 | jq -r '.[] | .name')
+mapfile -t ALL_TOOLS < <(mcp_tools ls --format json 2>/dev/null | jq -r '.[] | .name')
 
 if [ ${#ALL_TOOLS[@]} -eq 0 ]; then
     log_error "No tools found"

--- a/scripts/run_all_tools.sh
+++ b/scripts/run_all_tools.sh
@@ -59,6 +59,23 @@ REPORT_FILE="${ARTIFACTS_DIR}/tools_report.jsonl"
 # Ensure artifacts directory exists
 mkdir -p "${ARTIFACTS_DIR}"
 
+# Build gateway-arg flags for legacy catalog mode.
+# Recent docker-mcp versions always enable the profiles feature, which makes
+# 'docker mcp server enable' obsolete.  Passing --catalog / --servers to the
+# gateway forces it into legacy catalog mode so tool calls work without a profile.
+# NEXTDNS_GATEWAY_ARGS is set by gateway_e2e_run.sh; falls back to empty so
+# this script can still be invoked standalone against a pre-configured default profile.
+_MCP_GATEWAY_ARGS=()
+if [ -n "${NEXTDNS_GATEWAY_ARGS:-}" ]; then
+    for _arg in ${NEXTDNS_GATEWAY_ARGS}; do
+        _MCP_GATEWAY_ARGS+=("--gateway-arg=${_arg}")
+    done
+fi
+
+mcp_tools() {
+    docker mcp tools "${_MCP_GATEWAY_ARGS[@]}" "$@"
+}
+
 log_info "Starting NextDNS MCP tools enumeration and execution"
 log_info "Allow writes: ${ALLOW_WRITES}"
 log_info "Report file: ${REPORT_FILE}"
@@ -70,7 +87,7 @@ log_info "Report file: ${REPORT_FILE}"
 log_info "Performing preflight checks..."
 
 # Check Docker MCP is responding
-if ! docker mcp tools ls >/dev/null 2>&1; then
+if ! mcp_tools ls >/dev/null 2>&1; then
     log_error "Failed to enumerate tools from Docker MCP"
     log_error ""
     log_error "Troubleshooting steps:"
@@ -85,13 +102,13 @@ log_success "Docker MCP is responding"
 
 # Parse tool names - tools ls returns an array of tool objects
 # Filter out MCP Gateway built-in tools (mcp-*, code-*) - only test NextDNS tools
-mapfile -t ALL_TOOLS < <(docker mcp tools ls --format json 2>&1 | jq -r '.[] | .name')
+mapfile -t ALL_TOOLS < <(mcp_tools ls --format json 2>&1 | jq -r '.[] | .name')
 
 if [ ${#ALL_TOOLS[@]} -eq 0 ]; then
     log_error "No tools found"
     log_error "The MCP server may not be properly configured"
     log_error "Run: docker mcp catalog import ./catalog.yaml"
-    log_error "Run: docker mcp server enable nextdns"
+    log_error "Run: scripts/gateway_e2e_run.sh to configure the server"
     exit 1
 fi
 
@@ -120,7 +137,7 @@ if [ "${ALLOW_WRITES}" = "true" ]; then
     PROFILE_NAME="E2E Test Profile ${TIMESTAMP}"
     
     # Call createProfile using key=value syntax (Docker MCP CLI format)
-    PROFILE_RESULT=$(docker mcp tools call createProfile "name=${PROFILE_NAME}" 2>&1 || echo "")
+    PROFILE_RESULT=$(dmcp_tools call createProfile "name=${PROFILE_NAME}" 2>&1 || echo "")
     CREATE_EXIT_CODE=$?
     
     # Extract profile ID from response - filter out Docker MCP timing info, then parse JSON
@@ -162,7 +179,7 @@ else
     # In read-only mode, get first available profile
     log_info "Fetching existing profile for read-only tests..."
     
-    PROFILES_RESULT=$(docker mcp tools call listProfiles '{}' 2>&1 | grep -E '^\{' || echo "")
+    PROFILES_RESULT=$(mcp_tools call listProfiles '{}' 2>&1 | grep -E '^\{' || echo "")
     
     if [ -z "${PROFILES_RESULT}" ]; then
         log_error "Failed to fetch profiles"
@@ -390,22 +407,22 @@ for TOOL_NAME in "${TOOL_NAMES[@]}"; do
         updateAllowlistEntry)
             # Ensure entry exists before trying to update it
             log_info "  Pre-setup: Adding allowlist entry for update test"
-            docker mcp tools call addToAllowlist "profile_id=${PROFILE_ID}" "id=test-example.com" >/dev/null 2>&1 || true
+            mcp_tools call addToAllowlist "profile_id=${PROFILE_ID}" "id=test-example.com" >/dev/null 2>&1 || true
             ;;
         updateDenylistEntry)
             # Ensure entry exists before trying to update it
             log_info "  Pre-setup: Adding denylist entry for update test"
-            docker mcp tools call addToDenylist "profile_id=${PROFILE_ID}" "id=test-example.com" >/dev/null 2>&1 || true
+            mcp_tools call addToDenylist "profile_id=${PROFILE_ID}" "id=test-example.com" >/dev/null 2>&1 || true
             ;;
         updateParentalControlCategoryEntry)
             # Ensure category exists before trying to update it
             log_info "  Pre-setup: Adding parental control category for update test"
-            docker mcp tools call addToParentalControlCategories "profile_id=${PROFILE_ID}" "id=gambling" >/dev/null 2>&1 || true
+            mcp_tools call addToParentalControlCategories "profile_id=${PROFILE_ID}" "id=gambling" >/dev/null 2>&1 || true
             ;;
         updateParentalControlServiceEntry)
             # Ensure service exists before trying to update it
             log_info "  Pre-setup: Adding parental control service for update test"
-            docker mcp tools call addToParentalControlServices "profile_id=${PROFILE_ID}" "id=tiktok" >/dev/null 2>&1 || true
+            mcp_tools call addToParentalControlServices "profile_id=${PROFILE_ID}" "id=tiktok" >/dev/null 2>&1 || true
             ;;
     esac
     
@@ -422,7 +439,7 @@ for TOOL_NAME in "${TOOL_NAMES[@]}"; do
     
     while [ ${ATTEMPT} -le ${MAX_RETRIES} ]; do
         set +e
-        TOOL_OUTPUT=$(docker mcp tools call --format json "${TOOL_NAME}" ${TOOL_ARGS} 2>&1)
+        TOOL_OUTPUT=$(mcp_tools call --format json "${TOOL_NAME}" ${TOOL_ARGS} 2>&1)
         EXIT_CODE=$?
         set -e
         
@@ -522,7 +539,7 @@ if [ -n "${CREATED_PROFILE_ID}" ]; then
     log_info "Step 3: Cleaning up test profile..."
     
     # Call deleteProfile using key=value syntax
-    DELETE_RESULT=$(docker mcp tools call deleteProfile "profile_id=${CREATED_PROFILE_ID}" 2>&1 || echo "")
+    DELETE_RESULT=$(mcp_tools call deleteProfile "profile_id=${CREATED_PROFILE_ID}" 2>&1 || echo "")
     DELETE_EXIT_CODE=$?
     
     if [ ${DELETE_EXIT_CODE} -eq 0 ]; then

--- a/scripts/run_all_tools.sh
+++ b/scripts/run_all_tools.sh
@@ -137,7 +137,7 @@ if [ "${ALLOW_WRITES}" = "true" ]; then
     PROFILE_NAME="E2E Test Profile ${TIMESTAMP}"
     
     # Call createProfile using key=value syntax (Docker MCP CLI format)
-    PROFILE_RESULT=$(dmcp_tools call createProfile "name=${PROFILE_NAME}" 2>&1 || echo "")
+    PROFILE_RESULT=$(mcp_tools call createProfile "name=${PROFILE_NAME}" 2>&1 || echo "")
     CREATE_EXIT_CODE=$?
     
     # Extract profile ID from response - filter out Docker MCP timing info, then parse JSON

--- a/scripts/run_all_tools.sh
+++ b/scripts/run_all_tools.sh
@@ -102,7 +102,7 @@ log_success "Docker MCP is responding"
 
 # Parse tool names - tools ls returns an array of tool objects
 # Filter out MCP Gateway built-in tools (mcp-*, code-*) - only test NextDNS tools
-mapfile -t ALL_TOOLS < <(docker mcp tools --format json "${_MCP_GATEWAY_ARGS[@]}" ls 2>/dev/null | jq -r '.[] | .name')
+mapfile -t ALL_TOOLS < <(docker mcp tools "${_MCP_GATEWAY_ARGS[@]}" ls 2>/dev/null | grep '^ - ' | awk '{print $2}')
 
 if [ ${#ALL_TOOLS[@]} -eq 0 ]; then
     log_error "No tools found"

--- a/src/nextdns_mcp/__init__.py
+++ b/src/nextdns_mcp/__init__.py
@@ -3,4 +3,4 @@
 SPDX-License-Identifier: MIT
 """
 
-__version__ = "2.0.12"
+__version__ = "2.0.13"

--- a/uv.lock
+++ b/uv.lock
@@ -1,9 +1,13 @@
 version = 1
 revision = 3
 requires-python = ">=3.14"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
 
 [options]
-exclude-newer = "2026-04-20T12:31:48.01308559Z"
+exclude-newer = "2026-04-26T13:32:21.583975562Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -94,11 +98,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "7.0.5"
+version = "7.0.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/dd/57fe3fdb6e65b25a5987fd2cdc7e22db0aef508b91634d2e57d22928d41b/cachetools-7.0.5.tar.gz", hash = "sha256:0cd042c24377200c1dcd225f8b7b12b0ca53cc2c961b43757e774ebe190fd990", size = 37367, upload-time = "2026-03-09T20:51:29.451Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/7b/1755ed2c6bfabd1d98b37ae73152f8dcf94aa40fee119d163c19ed484704/cachetools-7.0.6.tar.gz", hash = "sha256:e5d524d36d65703a87243a26ff08ad84f73352adbeafb1cde81e207b456aaf24", size = 37526, upload-time = "2026-04-20T19:02:23.289Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/f3/39cf3367b8107baa44f861dc802cbf16263c945b62d8265d36034fc07bea/cachetools-7.0.5-py3-none-any.whl", hash = "sha256:46bc8ebefbe485407621d0a4264b23c080cedd913921bad7ac3ed2f26c183114", size = 13918, upload-time = "2026-03-09T20:51:27.33Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/cf76242a5da1410917107ff14551764aa405a5fd10cd10cf9a5ca8fa77f4/cachetools-7.0.6-py3-none-any.whl", hash = "sha256:4e94956cfdd3086f12042cdd29318f5ced3893014f7d0d059bf3ead3f85b7f8b", size = 13976, upload-time = "2026-04-20T19:02:21.187Z" },
 ]
 
 [[package]]
@@ -116,11 +120,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.2.25"
+version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
 ]
 
 [[package]]
@@ -199,14 +203,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]
@@ -259,60 +263,60 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.7"
+version = "47.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb", size = 830863, upload-time = "2026-04-24T19:54:57.056Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
-    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
-    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
-    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
-    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
-    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
-    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
-    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
-    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
-    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
-    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
-    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
-    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
-    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
-    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
-    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
-    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/98/40dfe932134bdcae4f6ab5927c87488754bf9eb79297d7e0070b78dd58e9/cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0", size = 7912214, upload-time = "2026-04-24T19:53:03.864Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c6/2733531243fba725f58611b918056b277692f1033373dcc8bd01af1c05d4/cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973", size = 4644617, upload-time = "2026-04-24T19:53:06.909Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/b27be1a670a9b87f855d211cf0e1174a5d721216b7616bd52d8581d912ed/cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8", size = 4668186, upload-time = "2026-04-24T19:53:09.053Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b9/8443cfe5d17d482d348cee7048acf502bb89a51b6382f06240fd290d4ca3/cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b", size = 4651244, upload-time = "2026-04-24T19:53:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5e/13ed0cdd0eb88ba159d6dd5ebfece8cb901dbcf1ae5ac4072e28b55d3153/cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92", size = 5252906, upload-time = "2026-04-24T19:53:13.532Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/ed058e1df0f33d440217cd120d41d5dda9dd215a80b8187f68483185af82/cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7", size = 4701842, upload-time = "2026-04-24T19:53:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3d30986b30fdbd9e969abbdf8ba00ed0618615144341faeb57f395a084fe/cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93", size = 4289313, upload-time = "2026-04-24T19:53:17.755Z" },
+    { url = "https://files.pythonhosted.org/packages/df/fd/32db38e3ad0cb331f0691cb4c7a8a6f176f679124dee746b3af6633db4d9/cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac", size = 4650964, upload-time = "2026-04-24T19:53:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/86/53/5395d944dfd48cb1f67917f533c609c34347185ef15eb4308024c876f274/cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f", size = 5207817, upload-time = "2026-04-24T19:53:22.498Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4f/e5711b28e1901f7d480a2b1b688b645aa4c77c73f10731ed17e7f7db3f0d/cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8", size = 4701544, upload-time = "2026-04-24T19:53:24.356Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/c8ddc25de3010fc8da447648f5a092c40e7a8fadf01dd6d255d9c0b9373d/cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318", size = 4783536, upload-time = "2026-04-24T19:53:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b6/d4a68f4ea999c6d89e8498579cba1c5fcba4276284de7773b17e4fa69293/cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001", size = 4926106, upload-time = "2026-04-24T19:53:28.686Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ed/5f524db1fade9c013aa618e1c99c6ed05e8ffc9ceee6cda22fed22dda3f4/cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203", size = 3258581, upload-time = "2026-04-24T19:53:31.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dc/1b901990b174786569029f67542b3edf72ac068b6c3c8683c17e6a2f5363/cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa", size = 3775309, upload-time = "2026-04-24T19:53:33.054Z" },
+    { url = "https://files.pythonhosted.org/packages/14/88/7aa18ad9c11bc87689affa5ce4368d884b517502d75739d475fc6f4a03c7/cryptography-47.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:be12cb6a204f77ed968bcefe68086eb061695b540a3dd05edac507a3111b25f0", size = 7904299, upload-time = "2026-04-24T19:53:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/07/55/c18f75724544872f234678fdedc871391722cb34a2aee19faa9f63100bb2/cryptography-47.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2ebd84adf0728c039a3be2700289378e1c164afc6748df1a5ed456767bef9ba7", size = 4631180, upload-time = "2026-04-24T19:53:37.517Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/65/31a5cc0eaca99cec5bafffe155d407115d96136bb161e8b49e0ef73f09a7/cryptography-47.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f68d6fbc7fbbcfb0939fea72c3b96a9f9a6edfc0e1b1d29778a2066030418b1", size = 4653529, upload-time = "2026-04-24T19:53:39.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/bc/641c0519a495f3bfd0421b48d7cd325c4336578523ccd76ea322b6c29c7a/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:6651d32eff255423503aa276739da98c30f26c40cbeffcc6048e0d54ef704c0c", size = 4638570, upload-time = "2026-04-24T19:53:42.129Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f2/300327b0a47f6dc94dd8b71b57052aefe178bb51745073d73d80604f11ab/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3fb8fa48075fad7193f2e5496135c6a76ac4b2aa5a38433df0a539296b377829", size = 5238019, upload-time = "2026-04-24T19:53:44.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/5b5cf994391d4bf9d9c7efd4c66aabe4d95227256627f8fea6cff7dfadbd/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11438c7518132d95f354fa01a4aa2f806d172a061a7bed18cf18cbdacdb204d7", size = 4686832, upload-time = "2026-04-24T19:53:47.015Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2c/ae950e28fd6475c852fc21a44db3e6b5bcc1261d1e370f2b6e42fa800fef/cryptography-47.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8c1a736bbb3288005796c3f7ccb9453360d7fed483b13b9f468aea5171432923", size = 4269301, upload-time = "2026-04-24T19:53:48.97Z" },
+    { url = "https://files.pythonhosted.org/packages/67/fb/6a39782e150ffe5cc1b0018cb6ddc48bf7ca62b498d7539ffc8a758e977d/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:f1557695e5c2b86e204f6ce9470497848634100787935ab7adc5397c54abd7ab", size = 4638110, upload-time = "2026-04-24T19:53:51.011Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d7/0b3c71090a76e5c203164a47688b697635ece006dcd2499ab3a4dbd3f0bd/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:f9a034b642b960767fb343766ae5ba6ad653f2e890ddd82955aef288ffea8736", size = 5194988, upload-time = "2026-04-24T19:53:52.962Z" },
+    { url = "https://files.pythonhosted.org/packages/63/33/63a961498a9df51721ab578c5a2622661411fc520e00bd83b0cc64eb20c4/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b1c76fca783aa7698eb21eb14f9c4aa09452248ee54a627d125025a43f83e7a7", size = 4686563, upload-time = "2026-04-24T19:53:55.274Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/5ee5b145248f92250de86145d1c1d6edebbd57a7fe7caa4dedb5d4cf06a1/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4f7722c97826770bab8ae92959a2e7b20a5e9e9bf4deae68fd86c3ca457bab52", size = 4770094, upload-time = "2026-04-24T19:53:57.753Z" },
+    { url = "https://files.pythonhosted.org/packages/92/43/21d220b2da5d517773894dacdcdb5c682c28d3fffce65548cb06e87d5501/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:09f6d7bf6724f8db8b32f11eccf23efc8e759924bc5603800335cf8859a3ddbd", size = 4913811, upload-time = "2026-04-24T19:54:00.236Z" },
+    { url = "https://files.pythonhosted.org/packages/31/98/dc4ad376ac5f1a1a7d4a83f7b0c6f2bcad36b5d2d8f30aeb482d3a7d9582/cryptography-47.0.0-cp314-cp314t-win32.whl", hash = "sha256:6eebcaf0df1d21ce1f90605c9b432dd2c4f4ab665ac29a40d5e3fc68f51b5e63", size = 3237158, upload-time = "2026-04-24T19:54:02.606Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/da/97f62d18306b5133468bc3f8cc73a3111e8cdc8cf8d3e69474d6e5fd2d1b/cryptography-47.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:51c9313e90bd1690ec5a75ed047c27c0b8e6c570029712943d6116ef9a90620b", size = 3758706, upload-time = "2026-04-24T19:54:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/34/a4fae8ae7c3bc227460c9ae43f56abf1b911da0ec29e0ebac53bb0a4b6b7/cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4", size = 7904072, upload-time = "2026-04-24T19:54:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/01/64/d7b1e54fdb69f22d24a64bb3e88dc718b31c7fb10ef0b9691a3cf7eeea6e/cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27", size = 4635767, upload-time = "2026-04-24T19:54:08.519Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/7b/cca826391fb2a94efdcdfe4631eb69306ee1cff0b22f664a412c90713877/cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10", size = 4654350, upload-time = "2026-04-24T19:54:10.795Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/4b57bcc823f42a991627c51c2f68c9fd6eb1393c1756aac876cba2accae2/cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b", size = 4643394, upload-time = "2026-04-24T19:54:13.275Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/2c5fbeea70adbbca2bbae865e1d605d6a4a7f8dbd9d33eaf69645087f06c/cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74", size = 5225777, upload-time = "2026-04-24T19:54:15.18Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/b8/ac57107ef32749d2b244e36069bb688792a363aaaa3acc9e3cf84c130315/cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515", size = 4688771, upload-time = "2026-04-24T19:54:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fc/9f1de22ff8be99d991f240a46863c52d475404c408886c5a38d2b5c3bb26/cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc", size = 4270753, upload-time = "2026-04-24T19:54:19.963Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/d70c852797aa68e8e48d12e5a87170c43f67bb4a59403627259dd57d15de/cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca", size = 4642911, upload-time = "2026-04-24T19:54:21.818Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/51/661cbee74f594c5d97ff82d34f10d5551c085ca4668645f4606ebd22bd5d/cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76", size = 5181411, upload-time = "2026-04-24T19:54:24.376Z" },
+    { url = "https://files.pythonhosted.org/packages/94/87/f2b6c374a82cf076cfa1416992ac8e8ec94d79facc37aec87c1a5cb72352/cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe", size = 4688262, upload-time = "2026-04-24T19:54:26.946Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/8b7462f4acf21ec509616f0245018bb197194ab0b65c2ea21a0bdd53c0eb/cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31", size = 4775506, upload-time = "2026-04-24T19:54:28.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/75/158e494e4c08dc05e039da5bb48553826bd26c23930cf8d3cd5f21fa8921/cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7", size = 4912060, upload-time = "2026-04-24T19:54:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bd/0a9d3edbf5eadbac926d7b9b3cd0c4be584eeeae4a003d24d9eda4affbbd/cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310", size = 3248487, upload-time = "2026-04-24T19:54:33.494Z" },
+    { url = "https://files.pythonhosted.org/packages/60/80/5681af756d0da3a599b7bdb586fac5a1540f1bcefd2717a20e611ddade45/cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769", size = 3755737, upload-time = "2026-04-24T19:54:35.408Z" },
 ]
 
 [[package]]
 name = "cyclopts"
-version = "4.10.2"
+version = "4.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -320,9 +324,9 @@ dependencies = [
     { name = "rich" },
     { name = "rich-rst" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/2c/fced34890f6e5a93a4b7afb2c71e8eee2a0719fb26193a0abf159ecb714d/cyclopts-4.10.2.tar.gz", hash = "sha256:d7b950457ef2563596d56331f80cbbbf86a2772535fb8b315c4f03bc7e6127f1", size = 166664, upload-time = "2026-04-08T23:57:45.805Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/fa/eff8f1abae783bade9b5e9bafafd0040d4dbf51988f9384bfdc0326ba1fc/cyclopts-4.11.0.tar.gz", hash = "sha256:1ffcb9990dbd56b90da19980d31596de9e99019980a215a5d76cf88fe452e94d", size = 170690, upload-time = "2026-04-23T00:23:36.858Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/bd/05055d8360cef0757d79367157f3b15c0a0715e81e08f86a04018ec045f0/cyclopts-4.10.2-py3-none-any.whl", hash = "sha256:a1f2d6f8f7afac9456b48f75a40b36658778ddc9c6d406b520d017ae32c990fe", size = 204314, upload-time = "2026-04-08T23:57:46.969Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/37/197db187c260d24d4be1f09d427f59f3fb9a89bcf1354e23865c7bff7607/cyclopts-4.11.0-py3-none-any.whl", hash = "sha256:34318e3823b44b5baa754a5e37ec70a5c17dc81c65e4295ed70e17bc1aeae50d", size = 208494, upload-time = "2026-04-23T00:23:34.948Z" },
 ]
 
 [[package]]
@@ -464,11 +468,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
 ]
 
 [[package]]
@@ -725,7 +729,7 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.20.1"
+version = "1.20.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
@@ -733,23 +737,23 @@ dependencies = [
     { name = "pathspec" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/3d/5b373635b3146264eb7a68d09e5ca11c305bbb058dfffbb47c47daf4f632/mypy-1.20.1.tar.gz", hash = "sha256:6fc3f4ecd52de81648fed1945498bf42fa2993ddfad67c9056df36ae5757f804", size = 3815892, upload-time = "2026-04-13T02:46:51.474Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349, upload-time = "2026-04-21T17:12:28.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/cd/db831e84c81d57d4886d99feee14e372f64bbec6a9cb1a88a19e243f2ef5/mypy-1.20.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:12927b9c0ed794daedcf1dab055b6c613d9d5659ac511e8d936d96f19c087d12", size = 14483064, upload-time = "2026-04-13T02:45:26.901Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/82/74e62e7097fa67da328ac8ece8de09133448c04d20ddeaeba251a3000f01/mypy-1.20.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:752507dd481e958b2c08fc966d3806c962af5a9433b5bf8f3bdd7175c20e34fe", size = 13335694, upload-time = "2026-04-13T02:46:12.514Z" },
-    { url = "https://files.pythonhosted.org/packages/74/c4/97e9a0abe4f3cdbbf4d079cb87a03b786efeccf5bf2b89fe4f96939ab2e6/mypy-1.20.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c614655b5a065e56274c6cbbe405f7cf7e96c0654db7ba39bc680238837f7b08", size = 13726365, upload-time = "2026-04-13T02:45:17.422Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/aa/a19d884a8d28fcd3c065776323029f204dbc774e70ec9c85eba228b680de/mypy-1.20.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c3f6221a76f34d5100c6d35b3ef6b947054123c3f8d6938a4ba00b1308aa572", size = 14693472, upload-time = "2026-04-13T02:46:41.253Z" },
-    { url = "https://files.pythonhosted.org/packages/84/44/cc9324bd21cf786592b44bf3b5d224b3923c1230ec9898d508d00241d465/mypy-1.20.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4bdfc06303ac06500af71ea0cdbe995c502b3c9ba32f3f8313523c137a25d1b6", size = 14919266, upload-time = "2026-04-13T02:46:28.37Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/dc/779abb25a8c63e8f44bf5a336217fa92790fa17e0c40e0c725d10cb01bbd/mypy-1.20.1-cp314-cp314-win_amd64.whl", hash = "sha256:0131edd7eba289973d1ba1003d1a37c426b85cdef76650cd02da6420898a5eb3", size = 11049713, upload-time = "2026-04-13T02:45:57.673Z" },
-    { url = "https://files.pythonhosted.org/packages/28/08/4172be2ad7de9119b5a92ca36abbf641afdc5cb1ef4ae0c3a8182f29674f/mypy-1.20.1-cp314-cp314-win_arm64.whl", hash = "sha256:33f02904feb2c07e1fdf7909026206396c9deeb9e6f34d466b4cfedb0aadbbe4", size = 9999819, upload-time = "2026-04-13T02:46:35.039Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/af/af9e46b0c8eabbce9fc04a477564170f47a1c22b308822282a59b7ff315f/mypy-1.20.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:168472149dd8cc505c98cefd21ad77e4257ed6022cd5ed2fe2999bed56977a5a", size = 15547508, upload-time = "2026-04-13T02:46:25.588Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/cd/39c9e4ad6ba33e069e5837d772a9e6c304b4a5452a14a975d52b36444650/mypy-1.20.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:eb674600309a8f22790cca883a97c90299f948183ebb210fbef6bcee07cb1986", size = 14399557, upload-time = "2026-04-13T02:46:10.021Z" },
-    { url = "https://files.pythonhosted.org/packages/83/c1/3fd71bdc118ffc502bf57559c909927bb7e011f327f7bb8e0488e98a5870/mypy-1.20.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef2b2e4cc464ba9795459f2586923abd58a0055487cbe558cb538ea6e6bc142a", size = 15045789, upload-time = "2026-04-13T02:45:10.81Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/73/6f07ff8b57a7d7b3e6e5bf34685d17632382395c8bb53364ec331661f83e/mypy-1.20.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dee461d396dd46b3f0ed5a098dbc9b8860c81c46ad44fa071afcfbc149f167c9", size = 15850795, upload-time = "2026-04-13T02:45:03.349Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/e2/f7dffec1c7767078f9e9adf0c786d1fe0ff30964a77eb213c09b8b58cb76/mypy-1.20.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e364926308b3e66f1361f81a566fc1b2f8cd47fc8525e8136d4058a65a4b4f02", size = 16088539, upload-time = "2026-04-13T02:46:17.841Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/76/e0dee71035316e75a69d73aec2f03c39c21c967b97e277fd0ef8fd6aec66/mypy-1.20.1-cp314-cp314t-win_amd64.whl", hash = "sha256:a0c17fbd746d38c70cbc42647cfd884f845a9708a4b160a8b4f7e70d41f4d7fa", size = 12575567, upload-time = "2026-04-13T02:45:34.795Z" },
-    { url = "https://files.pythonhosted.org/packages/22/a8/7ed43c9d9c3d1468f86605e323a5d97e411a448790a00f07e779f3211a46/mypy-1.20.1-cp314-cp314t-win_arm64.whl", hash = "sha256:db2cb89654626a912efda69c0d5c1d22d948265e2069010d3dde3abf751c7d08", size = 10378823, upload-time = "2026-04-13T02:45:13.35Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/28/926bd972388e65a39ee98e188ccf67e81beb3aacfd5d6b310051772d974b/mypy-1.20.1-py3-none-any.whl", hash = "sha256:1aae28507f253fe82d883790d1c0a0d35798a810117c88184097fe8881052f06", size = 2636553, upload-time = "2026-04-13T02:46:30.45Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d1/b4ec96b0ecc620a4443570c6e95c867903428cfcde4206518eafdd5880c3/mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:419413398fe250aae057fd2fe50166b61077083c9b82754c341cf4fd73038f30", size = 14524561, upload-time = "2026-04-21T17:06:27.325Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/d2c2ff4fa66bc49477d32dfa26e8a167ba803ea6a69c5efb416036909d30/mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924", size = 13363883, upload-time = "2026-04-21T17:11:11.239Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/56/983916806bf4eddeaaa2c9230903c3669c6718552a921154e1c5182c701f/mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb", size = 13742945, upload-time = "2026-04-21T17:08:34.181Z" },
+    { url = "https://files.pythonhosted.org/packages/19/65/0cd9285ab010ee8214c83d67c6b49417c40d86ce46f1aa109457b5a9b8d7/mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc", size = 14706163, upload-time = "2026-04-21T17:05:15.51Z" },
+    { url = "https://files.pythonhosted.org/packages/94/97/48ff3b297cafcc94d185243a9190836fb1b01c1b0918fff64e941e973cc9/mypy-1.20.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fef51b01e638974a6e69885687e9bd40c8d1e09a6cd291cca0619625cf1f558", size = 14938677, upload-time = "2026-04-21T17:05:39.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a1/1b4233d255bdd0b38a1f284feeb1c143ca508c19184964e22f8d837ec851/mypy-1.20.2-cp314-cp314-win_amd64.whl", hash = "sha256:913485a03f1bcf5d279409a9d2b9ed565c151f61c09f29991e5faa14033da4c8", size = 11089322, upload-time = "2026-04-21T17:06:44.29Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/ce7ee2ba36aeb954ba50f18fa25d9c1188578654b97d02a66a15b6f09531/mypy-1.20.2-cp314-cp314-win_arm64.whl", hash = "sha256:c3bae4f855d965b5453784300c12ffc63a548304ac7f99e55d4dc7c898673aa3", size = 10017775, upload-time = "2026-04-21T17:07:20.732Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a1/9d93a7d0b5859af0ead82b4888b46df6c8797e1bc5e1e262a08518c6d48e/mypy-1.20.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2de3dcea53babc1c3237a19002bc3d228ce1833278f093b8d619e06e7cc79609", size = 15549002, upload-time = "2026-04-21T17:08:23.107Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d2/09a6a10ee1bf0008f6c144d9676f2ca6a12512151b4e0ad0ff6c4fac5337/mypy-1.20.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:52b176444e2e5054dfcbcb8c75b0b719865c96247b37407184bbfca5c353f2c2", size = 14401942, upload-time = "2026-04-21T17:07:31.837Z" },
+    { url = "https://files.pythonhosted.org/packages/57/da/9594b75c3c019e805250bed3583bdf4443ff9e6ef08f97e39ae308cb06f2/mypy-1.20.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:688c3312e5dadb573a2c69c82af3a298d43ecf9e6d264e0f95df960b5f6ac19c", size = 15041649, upload-time = "2026-04-21T17:09:34.653Z" },
+    { url = "https://files.pythonhosted.org/packages/97/77/f75a65c278e6e8eba2071f7f5a90481891053ecc39878cc444634d892abe/mypy-1.20.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29752dbbf8cc53f89f6ac096d363314333045c257c9c75cbd189ca2de0455744", size = 15864588, upload-time = "2026-04-21T17:11:44.936Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/46/1a4e1c66e96c1a3246ddf5403d122ac9b0a8d2b7e65730b9d6533ba7a6d3/mypy-1.20.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:803203d2b6ea644982c644895c2f78b28d0e208bba7b27d9b921e0ec5eb207c6", size = 16093956, upload-time = "2026-04-21T17:10:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2c/78a8851264dec38cd736ca5b8bc9380674df0dd0be7792f538916157716c/mypy-1.20.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9bcb8aa397ff0093c824182fd76a935a9ba7ad097fcbef80ae89bf6c1731d8ec", size = 12568661, upload-time = "2026-04-21T17:11:54.473Z" },
+    { url = "https://files.pythonhosted.org/packages/83/01/cd7318aa03493322ce275a0e14f4f52b8896335e4e79d4fb8153a7ad2b77/mypy-1.20.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e061b58443f1736f8a37c48978d7ab581636d6ab03e3d4f99e3fa90463bb9382", size = 10389240, upload-time = "2026-04-21T17:09:42.719Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/f23c163e25b11074188251b0b5a0342625fc1cdb6af604757174fa9acc9b/mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563", size = 2637314, upload-time = "2026-04-21T17:05:54.5Z" },
 ]
 
 [[package]]
@@ -763,7 +767,7 @@ wheels = [
 
 [[package]]
 name = "nextdns-mcp"
-version = "2.0.12"
+version = "2.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -819,24 +823,24 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.41.0"
+version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/8e/3778a7e87801d994869a9396b9fc2a289e5f9be91ff54a27d41eace494b0/opentelemetry_api-1.41.0.tar.gz", hash = "sha256:9421d911326ec12dee8bc933f7839090cad7a3f13fcfb0f9e82f8174dc003c09", size = 71416, upload-time = "2026-04-09T14:38:34.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/ee/99ab786653b3bda9c37ade7e24a7b607a1b1f696063172768417539d876d/opentelemetry_api-1.41.0-py3-none-any.whl", hash = "sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f", size = 69007, upload-time = "2026-04-09T14:38:11.833Z" },
+    { url = "https://files.pythonhosted.org/packages/29/59/3e7118ed140f76b0982ba4321bdaed1997a0473f9720de2d10788a577033/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f", size = 69007, upload-time = "2026-04-24T13:15:15.662Z" },
 ]
 
 [[package]]
 name = "packaging"
-version = "26.1"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
@@ -850,11 +854,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "1.0.4"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/17/9c3094b822982b9f1ea666d8580ce59000f61f87c1663556fb72031ad9ec/pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080", size = 133918, upload-time = "2026-04-23T01:46:22.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c9/8eed0486f074e9f1ca7f8ce5ad663e65f12fdab344028d658fa1b03d35e0/pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42", size = 56264, upload-time = "2026-04-23T01:46:20.606Z" },
 ]
 
 [[package]]
@@ -911,7 +915,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.13.2"
+version = "2.13.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -919,9 +923,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/e5/06d23afac9973109d1e3c8ad38e1547a12e860610e327c05ee686827dc37/pydantic-2.13.2.tar.gz", hash = "sha256:b418196607e61081c3226dcd4f0672f2a194828abb9109e9cfb84026564df2d1", size = 843836, upload-time = "2026-04-17T09:31:59.636Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/ca/b45c378e6e8d0b90577288b533e04e95b7afd61bb1d51b6c263176435489/pydantic-2.13.2-py3-none-any.whl", hash = "sha256:a525087f4c03d7e7456a3de89b64cd693d2229933bb1068b9af6befd5563694e", size = 471947, upload-time = "2026-04-17T09:31:57.541Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
 ]
 
 [package.optional-dependencies]
@@ -931,57 +935,57 @@ email = [
 
 [[package]]
 name = "pydantic-core"
-version = "2.46.2"
+version = "2.46.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/bb/4742f05b739b2478459bb16fa8470549518c802e06ddcf3f106c5081315e/pydantic_core-2.46.2.tar.gz", hash = "sha256:37bb079f9ee3f1a519392b73fda2a96379b31f2013c6b467fe693e7f2987f596", size = 471269, upload-time = "2026-04-17T09:10:07.017Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/96/a50ccb6b539ae780f73cea74905468777680e30c6c3bdf714b9d4c116ea0/pydantic_core-2.46.2-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:4f59b45f3ef8650c0c736a57f59031d47ed9df4c0a64e83796849d7d14863a2d", size = 2097111, upload-time = "2026-04-17T09:10:49.617Z" },
-    { url = "https://files.pythonhosted.org/packages/34/5f/fdead7b3afa822ab6e5a18ee0ecffd54937de1877c01ed13a342e0fb3f07/pydantic_core-2.46.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3a075a29ebef752784a91532a1a85be6b234ccffec0a9d7978a92696387c3da6", size = 1951904, upload-time = "2026-04-17T09:12:32.062Z" },
-    { url = "https://files.pythonhosted.org/packages/95/e0/1c5d547e550cdab1bec737492aa08865337af6fe7fc9b96f7f45f17d9519/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d12d786e30c04a9d307c5d7080bf720d9bac7f1668191d8e37633a9562749e2", size = 1978667, upload-time = "2026-04-17T09:11:35.589Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/cb/665ce629e218c8228302cb94beff4f6531082a2c87d3ecc3d5e63a26f392/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0d5e6d6343b0b5dcacb3503b5de90022968da8ed0ab9ab39d3eda71c20cbf84e", size = 2046721, upload-time = "2026-04-17T09:11:47.725Z" },
-    { url = "https://files.pythonhosted.org/packages/77/e9/6cb2cf60f54c1472bbdfce19d957553b43dbba79d1d7b2930a195c594785/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:233eebac0999b6b9ba76eb56f3ec8fce13164aa16b6d2225a36a79e0f95b5973", size = 2228483, upload-time = "2026-04-17T09:12:08.837Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/2a/93e018dd5571f781ebaeda8c0cf65398489d5bee9b1f484df0b6149b43b9/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9cc0eee720dd2f14f3b7c349469402b99ad81a174ab49d3533974529e9d93992", size = 2294663, upload-time = "2026-04-17T09:12:52.053Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/4f/49e57ca55c770c93d9bb046666a54949b42e3c9099a0c5fe94557873fe30/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83ee76bf2c9910513dbc19e7d82367131fa7508dedd6186a462393071cc11059", size = 2098742, upload-time = "2026-04-17T09:13:45.472Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/b0/6e46b5cd3332af665f794b8cdeea206618a8630bd9e7bcc36864518fce81/pydantic_core-2.46.2-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:d61db38eb4ee5192f0c261b7f2d38e420b554df8912245e3546aee5c45e2fd78", size = 2125922, upload-time = "2026-04-17T09:12:54.304Z" },
-    { url = "https://files.pythonhosted.org/packages/06/d1/40850c81585be443a2abfdf7f795f8fae831baf8e2f9b2133c8246ac671c/pydantic_core-2.46.2-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8f09a713d17bcd55da8ab02ebd9110c5246a49c44182af213b5212800af8bc83", size = 2183000, upload-time = "2026-04-17T09:10:59.027Z" },
-    { url = "https://files.pythonhosted.org/packages/04/af/8493d7dfa03ebb7866909e577c6aa65ea0de7377b86023cc51d0c8e11db3/pydantic_core-2.46.2-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:30cacc5fb696e64b8ef6fd31d9549d394dd7d52760db072eecb98e37e3af1677", size = 2180335, upload-time = "2026-04-17T09:12:57.01Z" },
-    { url = "https://files.pythonhosted.org/packages/72/5b/1f6a344c4ffdf284da41c6067b82d5ebcbd11ce1b515ae4b662d4adb6f61/pydantic_core-2.46.2-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:7ccfb105fcfe91a22bbb5563ad3dc124bc1aa75bfd2e53a780ab05f78cdf6108", size = 2330002, upload-time = "2026-04-17T09:12:02.958Z" },
-    { url = "https://files.pythonhosted.org/packages/25/ff/9a694126c12d6d2f48a0cafa6f8eef88ef0d8825600e18d03ff2e896c3b2/pydantic_core-2.46.2-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:13ffef637dc8370c249e5b26bd18e9a80a4fca3d809618c44e18ec834a7ca7a8", size = 2359920, upload-time = "2026-04-17T09:10:27.764Z" },
-    { url = "https://files.pythonhosted.org/packages/51/c8/3a35c763d68a9cb2675eb10ef242cf66c5d4701b28ae12e688d67d2c180e/pydantic_core-2.46.2-cp314-cp314-win32.whl", hash = "sha256:1b0ab6d756ca2704a938e6c31b53f290c2f9c10d3914235410302a149de1a83e", size = 1953701, upload-time = "2026-04-17T09:13:30.021Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/6a/f2726a780365f7dfd89d62036f984f7acb99978c60c5e1fa7c0cb898ed11/pydantic_core-2.46.2-cp314-cp314-win_amd64.whl", hash = "sha256:99ebade8c9ada4df975372d8dd25883daa0e379a05f1cd0c99aa0c04368d01a6", size = 2071867, upload-time = "2026-04-17T09:10:39.205Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/79/76baacb9feba3d7c399b245ca1a29c74ea0db04ea693811374827eec2290/pydantic_core-2.46.2-cp314-cp314-win_arm64.whl", hash = "sha256:de87422197cf7f83db91d89c86a21660d749b3cd76cd8a45d115b8e675670f02", size = 2017252, upload-time = "2026-04-17T09:10:26.175Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/3b/77c26938f817668d9ad9bab1a905cb23f11d9a3d4bf724d429b3e55a8eaf/pydantic_core-2.46.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:236f22b4a206b5b61db955396b7cf9e2e1ff77f372efe9570128ccfcd6a525eb", size = 2094545, upload-time = "2026-04-17T09:12:19.339Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/de/42c13f590e3c260966aa49bcdb1674774f975467c49abd51191e502bea28/pydantic_core-2.46.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c2012f64d2cd7cca50f49f22445aa5a88691ac2b4498ee0a9a977f8ca4f7289f", size = 1933953, upload-time = "2026-04-17T09:09:55.889Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/84/ebe3ebb3e2d8db656937cfa6f97f544cb7132f2307a4a7dfdcd0ea102a12/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d07d6c63106d3a9c9a333e2636f9c82c703b1a9e3b079299e58747964e4fdb72", size = 1974435, upload-time = "2026-04-17T09:10:12.371Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/15/0bf51ca6709477cd4ef86148b6d7844f3308f029eac361dd0383f1e17b1a/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c326a2b4b85e959d9a1fc3a11f32f84611b6ec07c053e1828a860edf8d068208", size = 2031113, upload-time = "2026-04-17T09:10:00.752Z" },
-    { url = "https://files.pythonhosted.org/packages/02/ae/b7b5af9b79db036d9e61a44c481c17a213dc8fc4b8b71fe6875a72fc778b/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ac8a65e798f2462552c00d2e013d532c94d646729dda98458beaf51f9ec7b120", size = 2236325, upload-time = "2026-04-17T09:10:33.227Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/ae/ecef7477b5a03d4a499708f7e75d2836452ebb70b776c2d64612b334f57a/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a3c2bc1cc8164bedbc160b7bb1e8cc1e8b9c27f69ae4f9ae2b976cdae02b2dd", size = 2278135, upload-time = "2026-04-17T09:10:23.287Z" },
-    { url = "https://files.pythonhosted.org/packages/db/e4/2f9d82faa47af6c39fc3f120145fd915971e1e0cb6b55b494fad9fdf8275/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e69aa5e10b7e8b1bb4a6888650fd12fcbf11d396ca11d4a44de1450875702830", size = 2109071, upload-time = "2026-04-17T09:11:06.149Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/9c/677cf10873fbd0b116575ab7b97c90482b21564f8a8040beb18edef7a577/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4e6df5c3301e65fb42bc5338bf9a1027a02b0a31dc7f54c33775229af474daf0", size = 2106028, upload-time = "2026-04-17T09:10:51.525Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/53/6a06183544daba51c059123a2064a99039df25f115a06bdb26f2ea177038/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2c2f6e32548ac8d559b47944effcf8ae4d81c161f6b6c885edc53bc08b8f192d", size = 2164816, upload-time = "2026-04-17T09:11:56.187Z" },
-    { url = "https://files.pythonhosted.org/packages/57/6f/10fcdd9e3eca66fc828eef0f6f5850f2dd3bca2c59e6e041fb8bc3da39be/pydantic_core-2.46.2-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:b089a81c58e6ea0485562bbbbbca4f65c0549521606d5ef27fba217aac9b665a", size = 2166130, upload-time = "2026-04-17T09:10:03.804Z" },
-    { url = "https://files.pythonhosted.org/packages/29/83/92d3fd0e0156cad2e3cb5c26de73794af78ac9fa0c22ab666e566dd67061/pydantic_core-2.46.2-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:7f700a6d6f64112ae9193709b84303bbab84424ad4b47d0253301aabce9dfc70", size = 2316605, upload-time = "2026-04-17T09:12:45.249Z" },
-    { url = "https://files.pythonhosted.org/packages/97/f1/facffdb970981068219582e499b8d0871ed163ffcc6b347de5c412669e4c/pydantic_core-2.46.2-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:67db6814beaa5fefe91101ec7eb9efda613795767be96f7cf58b1ca8c9ca9972", size = 2358385, upload-time = "2026-04-17T09:09:54.657Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/a1/b8160b2f22b2199467bc68581a4ed380643c16b348a27d6165c6c242d694/pydantic_core-2.46.2-cp314-cp314t-win32.whl", hash = "sha256:32fbc7447be8e3be99bf7869f7066308f16be55b61f9882c2cefc7931f5c7664", size = 1942373, upload-time = "2026-04-17T09:12:59.594Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/90/db89acabe5b150e11d1b59fe3d947dda2ef6abbfef5c82f056ff63802f5d/pydantic_core-2.46.2-cp314-cp314t-win_amd64.whl", hash = "sha256:b317a2b97019c0b95ce99f4f901ae383f40132da6706cdf1731066a73394c25c", size = 2052078, upload-time = "2026-04-17T09:10:19.96Z" },
-    { url = "https://files.pythonhosted.org/packages/97/32/e19b83ceb07a3f1bb21798407790bbc9a31740158fd132b94139cb84e16c/pydantic_core-2.46.2-cp314-cp314t-win_arm64.whl", hash = "sha256:7dcb9d40930dfad7ab6b20bcc6ca9d2b030b0f347a0cd9909b54bd53ead521b1", size = 2016941, upload-time = "2026-04-17T09:12:34.447Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/db/a7bcb4940183fda36022cd18ba8dd12f2dff40740ec7b58ce7457befa416/pydantic_core-2.46.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:afa3aa644f74e290cdede48a7b0bee37d1c35e71b05105f6b340d484af536d9b", size = 2097614, upload-time = "2026-04-20T14:44:38.374Z" },
+    { url = "https://files.pythonhosted.org/packages/24/35/e4066358a22e3e99519db370494c7528f5a2aa1367370e80e27e20283543/pydantic_core-2.46.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ced3310e51aa425f7f77da8bbbb5212616655bedbe82c70944320bc1dbe5e018", size = 1951896, upload-time = "2026-04-20T14:40:53.996Z" },
+    { url = "https://files.pythonhosted.org/packages/87/92/37cf4049d1636996e4b888c05a501f40a43ff218983a551d57f9d5e14f0d/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e29908922ce9da1a30b4da490bd1d3d82c01dcfdf864d2a74aacee674d0bfa34", size = 1979314, upload-time = "2026-04-20T14:41:49.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/9ff4d676dfbdfb2d591cf43f3d90ded01e15b1404fd101180ed2d62a2fd3/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ff69140423eea8ed2d5477df3ba037f671f5e897d206d921bc9fdc39613e7", size = 2056133, upload-time = "2026-04-20T14:42:23.574Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f0/405b442a4d7ba855b06eec8b2bf9c617d43b8432d099dfdc7bf999293495/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b675ab0a0d5b1c8fdb81195dc5bcefea3f3c240871cdd7ff9a2de8aa50772eb2", size = 2228726, upload-time = "2026-04-20T14:44:22.816Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f8/65cd92dd5a0bd89ba277a98ecbfaf6fc36bbd3300973c7a4b826d6ab1391/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0087084960f209a9a4af50ecd1fb063d9ad3658c07bb81a7a53f452dacbfb2ba", size = 2301214, upload-time = "2026-04-20T14:44:48.792Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/86/ef96a4c6e79e7a2d0410826a68fbc0eccc0fd44aa733be199d5fcac3bb87/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed42e6cc8e1b0e2b9b96e2276bad70ae625d10d6d524aed0c93de974ae029f9f", size = 2099927, upload-time = "2026-04-20T14:41:40.196Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/53/269caf30e0096e0a8a8f929d1982a27b3879872cca2d917d17c2f9fdf4fe/pydantic_core-2.46.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:f1771ce258afb3e4201e67d154edbbae712a76a6081079fe247c2f53c6322c22", size = 2128789, upload-time = "2026-04-20T14:41:15.868Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b0/1a6d9b6a587e118482910c244a1c5acf4d192604174132efd12bf0ac486f/pydantic_core-2.46.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a7610b6a5242a6c736d8ad47fd5fff87fcfe8f833b281b1c409c3d6835d9227f", size = 2173815, upload-time = "2026-04-20T14:44:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/87/56/e7e00d4041a7e62b5a40815590114db3b535bf3ca0bf4dca9f16cef25246/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:ff5e7783bcc5476e1db448bf268f11cb257b1c276d3e89f00b5727be86dd0127", size = 2181608, upload-time = "2026-04-20T14:41:28.933Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/22/4bd23c3d41f7c185d60808a1de83c76cf5aeabf792f6c636a55c3b1ec7f9/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:9d2e32edcc143bc01e95300671915d9ca052d4f745aa0a49c48d4803f8a85f2c", size = 2326968, upload-time = "2026-04-20T14:42:03.962Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ac/66cd45129e3915e5ade3b292cb3bc7fd537f58f8f8dbdaba6170f7cabb74/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d83d1c6b87fa56b521479cff237e626a292f3b31b6345c15a99121b454c1", size = 2369842, upload-time = "2026-04-20T14:41:35.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/dd4248abb84113615473aa20d5545b7c4cd73c8644003b5259686f93996c/pydantic_core-2.46.3-cp314-cp314-win32.whl", hash = "sha256:07bc6d2a28c3adb4f7c6ae46aa4f2d2929af127f587ed44057af50bf1ce0f505", size = 1959661, upload-time = "2026-04-20T14:41:00.042Z" },
+    { url = "https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl", hash = "sha256:8940562319bc621da30714617e6a7eaa6b98c84e8c685bcdc02d7ed5e7c7c44e", size = 2071686, upload-time = "2026-04-20T14:43:16.471Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/db/1cf77e5247047dfee34bc01fa9bca134854f528c8eb053e144298893d370/pydantic_core-2.46.3-cp314-cp314-win_arm64.whl", hash = "sha256:5dcbbcf4d22210ced8f837c96db941bdb078f419543472aca5d9a0bb7cddc7df", size = 2026907, upload-time = "2026-04-20T14:43:31.732Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c0/b3df9f6a543276eadba0a48487b082ca1f201745329d97dbfa287034a230/pydantic_core-2.46.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d0fe3dce1e836e418f912c1ad91c73357d03e556a4d286f441bf34fed2dbeecf", size = 2095047, upload-time = "2026-04-20T14:42:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/66/57/886a938073b97556c168fd99e1a7305bb363cd30a6d2c76086bf0587b32a/pydantic_core-2.46.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9ce92e58abc722dac1bf835a6798a60b294e48eb0e625ec9fd994b932ac5feee", size = 1934329, upload-time = "2026-04-20T14:43:49.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7c/b42eaa5c34b13b07ecb51da21761297a9b8eb43044c864a035999998f328/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03e6467f0f5ab796a486146d1b887b2dc5e5f9b3288898c1b1c3ad974e53e4a", size = 1974847, upload-time = "2026-04-20T14:42:10.737Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9b/92b42db6543e7de4f99ae977101a2967b63122d4b6cf7773812da2d7d5b5/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2798b6ba041b9d70acfb9071a2ea13c8456dd1e6a5555798e41ba7b0790e329c", size = 2041742, upload-time = "2026-04-20T14:40:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/19/46fbe1efabb5aa2834b43b9454e70f9a83ad9c338c1291e48bdc4fecf167/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9be3e221bdc6d69abf294dcf7aff6af19c31a5cdcc8f0aa3b14be29df4bd03b1", size = 2236235, upload-time = "2026-04-20T14:41:27.307Z" },
+    { url = "https://files.pythonhosted.org/packages/77/da/b3f95bc009ad60ec53120f5d16c6faa8cabdbe8a20d83849a1f2b8728148/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13936129ce841f2a5ddf6f126fea3c43cd128807b5a59588c37cf10178c2e64", size = 2282633, upload-time = "2026-04-20T14:44:33.271Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/401336117722e28f32fb8220df676769d28ebdf08f2f4469646d404c43a3/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28b5f2ef03416facccb1c6ef744c69793175fd27e44ef15669201601cf423acb", size = 2109679, upload-time = "2026-04-20T14:44:41.065Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/53/b289f9bc8756a32fe718c46f55afaeaf8d489ee18d1a1e7be1db73f42cc4/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:830d1247d77ad23852314f069e9d7ddafeec5f684baf9d7e7065ed46a049c4e6", size = 2108342, upload-time = "2026-04-20T14:42:50.144Z" },
+    { url = "https://files.pythonhosted.org/packages/10/5b/8292fc7c1f9111f1b2b7c1b0dcf1179edcd014fc3ea4517499f50b829d71/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0793c90c1a3c74966e7975eaef3ed30ebdff3260a0f815a62a22adc17e4c01c", size = 2157208, upload-time = "2026-04-20T14:42:08.133Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9e/f80044e9ec07580f057a89fc131f78dda7a58751ddf52bbe05eaf31db50f/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d2d0aead851b66f5245ec0c4fb2612ef457f8bbafefdf65a2bf9d6bac6140f47", size = 2167237, upload-time = "2026-04-20T14:42:25.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/84/6781a1b037f3b96be9227edbd1101f6d3946746056231bf4ac48cdff1a8d/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:2f40e4246676beb31c5ce77c38a55ca4e465c6b38d11ea1bd935420568e0b1ab", size = 2312540, upload-time = "2026-04-20T14:40:40.313Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/db/19c0839feeb728e7df03255581f198dfdf1c2aeb1e174a8420b63c5252e5/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:cf489cf8986c543939aeee17a09c04d6ffb43bfef8ca16fcbcc5cfdcbed24dba", size = 2369556, upload-time = "2026-04-20T14:41:09.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/15/3228774cb7cd45f5f721ddf1b2242747f4eb834d0c491f0c02d606f09fed/pydantic_core-2.46.3-cp314-cp314t-win32.whl", hash = "sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56", size = 1949756, upload-time = "2026-04-20T14:41:25.717Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2a/c79cf53fd91e5a87e30d481809f52f9a60dd221e39de66455cf04deaad37/pydantic_core-2.46.3-cp314-cp314t-win_amd64.whl", hash = "sha256:706d9d0ce9cf4593d07270d8e9f53b161f90c57d315aeec4fb4fd7a8b10240d8", size = 2051305, upload-time = "2026-04-20T14:43:18.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/db/d8182a7f1d9343a032265aae186eb063fe26ca4c40f256b21e8da4498e89/pydantic_core-2.46.3-cp314-cp314t-win_arm64.whl", hash = "sha256:77706aeb41df6a76568434701e0917da10692da28cb69d5fb6919ce5fdb07374", size = 2026310, upload-time = "2026-04-20T14:41:01.778Z" },
 ]
 
 [[package]]
 name = "pydantic-settings"
-version = "2.13.1"
+version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
 ]
 
 [[package]]
@@ -1246,27 +1250,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.11"
+version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
-    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
-    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
-    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
-    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
-    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
-    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
-    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
-    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]
@@ -1366,15 +1370,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.44.0"
+version = "0.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Release v2.0.13

### Changes
- Bump version from 2.0.12 to 2.0.13
- Weekly dependency updates via `uv lock --upgrade`
- Add weekly automated maintenance/release workflow (`.github/workflows/weekly-maintenance.yml`)
- Fix E2E gateway tests: replace obsolete `docker mcp server enable` with legacy catalog mode
- Fix typo: `dmcp_tools` → `mcp_tools` in `scripts/run_all_tools.sh`

### Dependency Updates
- authlib 1.6.11 → 1.7.0
- cachetools 7.0.5 → 7.1.0
- certifi 2026.2.25 → 2026.4.22
- click 8.3.2 → 8.3.3
- cryptography 46.0.7 → 47.0.0
- cyclopts 4.10.2 → 4.11.0
- idna 3.11 → 3.13
- mypy 1.20.1 → 1.20.2
- opentelemetry-api 1.41.0 → 1.41.1
- packaging 26.1 → 26.2
- pathspec 1.0.4 → 1.1.0
- pydantic 2.13.2 → 2.13.3
- pydantic-core 2.46.2 → 2.46.3
- pydantic-settings 2.13.1 → 2.14.0
- ruff 0.15.11 → 0.15.12
- uvicorn 0.44.0 → 0.46.0

### Testing
- ✅ 239 unit/integration tests passed