### PR TITLE
fix: add pull-requests+checks read perms to wait-checks job

### DIFF
--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -27,8 +27,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
-  checks: read
 
 # Prevent parallel weekly runs from racing each other
 concurrency:

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -27,6 +27,8 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
+  checks: read
 
 # Prevent parallel weekly runs from racing each other
 concurrency:

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -267,6 +267,9 @@ jobs:
     needs: [check, prepare]
     if: needs.prepare.result == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      checks: read
     outputs:
       checks_passed: ${{ steps.poll.outputs.checks_passed }}
 


### PR DESCRIPTION
## Problem

The `wait-checks` job in `weekly-maintenance.yml` was spending all 90 minutes printing:

```
Could not resolve HEAD SHA — retrying...
```

...then timing out with `checks_passed=false`, which caused the `Review Copilot Comments`, `Merge PR`, and `Create GitHub Release` jobs to all be skipped. This happened in every run (runs #2 and #3).

## Root Cause

The workflow-level `permissions` is set to `contents: read` only. The `wait-checks` job had no job-level permissions override, so its `GITHUB_TOKEN` lacked `pull-requests: read` (needed by `gh pr view`) and `checks: read` (needed by the check-runs API). Both calls silently returned empty/error, causing the endless retry loop.

## Fix

Added a `permissions` block to the `wait-checks` job:
```yaml
permissions:
  pull-requests: read
  checks: read
```
