### PR TITLE
fix: label weekly maintenance PRs with bump-patch

### DIFF
--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -122,6 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
       pull-requests: write
     outputs:
       new_version: ${{ steps.bump.outputs.new_version }}
@@ -249,6 +250,7 @@ jobs:
             > /tmp/pr_body.md
 
           PR_URL=$(gh pr create \
+            --label "bump-patch" \
             --title "chore: weekly maintenance — v${CURRENT_VERSION} -> v${NEW_VERSION}" \
             --body-file /tmp/pr_body.md \
             --base main \
@@ -504,4 +506,3 @@ jobs:
             --target main
 
           echo "✅ Release $TAG created — Docker images will build automatically"
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ LABEL org.opencontainers.image.description="Model Context Protocol server for Ne
 LABEL org.opencontainers.image.authors="NextDNS MCP Contributors"
 LABEL org.opencontainers.image.source="https://github.com/dmeiser/nextdns-mcp"
 LABEL org.opencontainers.image.documentation="https://github.com/dmeiser/nextdns-mcp/blob/main/README.md"
-LABEL org.opencontainers.image.version="2.0.16"
+LABEL org.opencontainers.image.version="2.0.17"
 LABEL org.opencontainers.image.licenses="MIT"
 
 # MCP-specific labels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nextdns-mcp"
-version = "2.0.16"
+version = "2.0.17"
 description = "NextDNS MCP Server - Model Context Protocol server for NextDNS API built with FastMCP"
 authors = [{name = "NextDNS MCP Contributors"}]
 license = {text = "MIT"}

--- a/src/nextdns_mcp/__init__.py
+++ b/src/nextdns_mcp/__init__.py
@@ -3,4 +3,4 @@
 SPDX-License-Identifier: MIT
 """
 
-__version__ = "2.0.16"
+__version__ = "2.0.17"


### PR DESCRIPTION
## Summary
- add the `bump-patch` label when the weekly maintenance workflow opens its release PR
- grant the workflow `issues: write` so the GitHub token can apply that label
- ensure merged weekly maintenance PRs satisfy the existing auto-release workflow conditions

## Testing
- not run (workflow change only)
