### PR TITLE
chore: replace fixed exclude-newer date with rolling 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,15 @@
 
 version: 2
 updates:
-updates:
   # --- Python (uv) ---
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+    # Only propose versions at least 7 days old, matching the uv
+    # `exclude-newer` cooldown in pyproject.toml.
+    cooldown:
+      default-days: 7
     allow:
       - dependency-type: "all"
     commit-message:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,4 +57,7 @@ profile = "black"
 line_length = 120
 
 [tool.uv]
-exclude-newer = "2026-07-06T23:59:59Z"
+# Rolling 7-day dependency cooldown: ignore releases published within the
+# last 7 days so the community can vet them first. Matches the Dependabot
+# `cooldown` in .github/dependabot.yml.
+exclude-newer = "1 week"

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-06T23:59:59Z"
+exclude-newer-span = "P1W"
 
 [[package]]
 name = "aiofile"


### PR DESCRIPTION
The absolute cutoff (2026-07-06) froze in time, so Dependabot PRs for freshly published releases (e.g. fastmcp 3.4.4, #107) failed uv resolution. Use a rolling 1-week exclude-newer duration instead, and add a matching 7-day cooldown to Dependabot so both sides stay in sync.

Also removes a duplicate 'updates:' key in dependabot.yml.