### PR TITLE
chore: release v3.1.4 and fix ruff 0.16.0 lints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ LABEL org.opencontainers.image.description="Model Context Protocol server for Ne
 LABEL org.opencontainers.image.authors="NextDNS MCP Contributors"
 LABEL org.opencontainers.image.source="https://github.com/dmeiser/nextdns-mcp"
 LABEL org.opencontainers.image.documentation="https://github.com/dmeiser/nextdns-mcp/blob/main/README.md"
-LABEL org.opencontainers.image.version="3.1.3"
+LABEL org.opencontainers.image.version="3.1.4"
 LABEL org.opencontainers.image.licenses="MIT"
 
 # MCP-specific labels

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -39,7 +39,7 @@ LABEL org.opencontainers.image.description="Model Context Protocol server for Ne
 LABEL org.opencontainers.image.authors="NextDNS MCP Contributors"
 LABEL org.opencontainers.image.source="https://github.com/dmeiser/nextdns-mcp"
 LABEL org.opencontainers.image.documentation="https://github.com/dmeiser/nextdns-mcp/blob/main/README.md"
-LABEL org.opencontainers.image.version="3.1.3"
+LABEL org.opencontainers.image.version="3.1.4"
 LABEL org.opencontainers.image.licenses="MIT"
 
 # MCP-specific labels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nextdns-mcp"
-version = "3.1.3"
+version = "3.1.4"
 description = "NextDNS MCP Server - Model Context Protocol server for NextDNS API built with FastMCP"
 authors = [{name = "NextDNS MCP Contributors"}]
 license = {text = "MIT"}

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -12,10 +12,9 @@ expected schemas for that grouped tool.
 import json
 import sys
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any
 
 import yaml
-
 
 # Mapping from grouped MCP tool names to the OpenAPI operationIds they dispatch to.
 # A response is valid if it conforms to at least one of the listed schemas.
@@ -125,13 +124,13 @@ GROUPED_TOOL_OPERATIONS: dict[str, list[str]] = {
 }
 
 
-def load_openapi_spec(spec_path: str) -> Dict[str, Any]:
+def load_openapi_spec(spec_path: str) -> dict[str, Any]:
     """Load and parse OpenAPI specification."""
     with open(spec_path, "r") as f:
         return yaml.safe_load(f)
 
 
-def get_operation_response_schema(spec: Dict[str, Any], operation_id: str) -> Optional[Dict[str, Any]]:
+def get_operation_response_schema(spec: dict[str, Any], operation_id: str) -> dict[str, Any] | None:
     """
     Extract the 200 response schema for a given operationId.
 
@@ -139,11 +138,10 @@ def get_operation_response_schema(spec: Dict[str, Any], operation_id: str) -> Op
     """
     # Search through all paths and operations
     paths = spec.get("paths", {})
-    for path, path_item in paths.items():
+    for path_item in paths.values():
         for method, operation in path_item.items():
-            if method in ["get", "post", "put", "patch", "delete"]:
-                if operation.get("operationId") == operation_id:
-                    # Found the operation, extract 200 response schema
+            if method in ["get", "post", "put", "patch", "delete"] and operation.get("operationId") == operation_id:
+                # Found the operation, extract 200 response schema
                     responses = operation.get("responses", {})
                     # Some operations return 200, others 201 (created)
                     for success_code in ("200", "201"):
@@ -175,7 +173,7 @@ def validate_field_type(value: Any, expected_type: str) -> bool:
     return isinstance(value, expected_python_type)
 
 
-def _resolve_json_pointer(spec: Dict[str, Any], pointer: str) -> Any:
+def _resolve_json_pointer(spec: dict[str, Any], pointer: str) -> Any:
     """Resolve a local JSON pointer (e.g. '#/components/schemas/Foo') in the spec."""
     if not pointer.startswith("#/"):
         return None
@@ -189,7 +187,7 @@ def _resolve_json_pointer(spec: Dict[str, Any], pointer: str) -> Any:
     return target
 
 
-def resolve_schema(spec: Optional[Dict[str, Any]], schema: Any, _seen: Optional[set[str]] = None) -> Any:
+def resolve_schema(spec: dict[str, Any] | None, schema: Any, _seen: set[str] | None = None) -> Any:
     """Recursively resolve ``$ref`` pointers and nested schema references.
 
     Returns a schema dict with all local references expanded. Cyclic references
@@ -208,7 +206,7 @@ def resolve_schema(spec: Optional[Dict[str, Any]], schema: Any, _seen: Optional[
         if target is None:
             return {}
         return resolve_schema(spec, target, _seen | {ref})
-    resolved: Dict[str, Any] = {}
+    resolved: dict[str, Any] = {}
     for key, value in schema.items():
         if key == "properties" and isinstance(value, dict):
             resolved[key] = {k: resolve_schema(spec, v, _seen) for k, v in value.items()}
@@ -221,7 +219,7 @@ def resolve_schema(spec: Optional[Dict[str, Any]], schema: Any, _seen: Optional[
     return resolved
 
 
-def validate_schema(data: Any, schema: Dict[str, Any], path: str = "$") -> list[str]:
+def validate_schema(data: Any, schema: dict[str, Any], path: str = "$") -> list[str]:
     """
     Recursively validate data against an OpenAPI schema.
 
@@ -344,7 +342,7 @@ def main():
     if tool_name in GROUPED_TOOL_OPERATIONS:
         operation_ids = GROUPED_TOOL_OPERATIONS[tool_name]
 
-    schemas: list[tuple[str, Dict[str, Any]]] = []
+    schemas: list[tuple[str, dict[str, Any]]] = []
     for op_id in operation_ids:
         schema = get_operation_response_schema(spec, op_id)
         if schema is not None:

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -142,15 +142,15 @@ def get_operation_response_schema(spec: dict[str, Any], operation_id: str) -> di
         for method, operation in path_item.items():
             if method in ["get", "post", "put", "patch", "delete"] and operation.get("operationId") == operation_id:
                 # Found the operation, extract 200 response schema
-                    responses = operation.get("responses", {})
-                    # Some operations return 200, others 201 (created)
-                    for success_code in ("200", "201"):
-                        success_response = responses.get(success_code, {})
-                        content = success_response.get("content", {})
-                        json_content = content.get("application/json", {})
-                        schema = json_content.get("schema")
-                        if schema:
-                            return schema
+                responses = operation.get("responses", {})
+                # Some operations return 200, others 201 (created)
+                for success_code in ("200", "201"):
+                    success_response = responses.get(success_code, {})
+                    content = success_response.get("content", {})
+                    json_content = content.get("application/json", {})
+                    schema = json_content.get("schema")
+                    if schema:
+                        return schema
 
     return None
 

--- a/src/nextdns_mcp/__init__.py
+++ b/src/nextdns_mcp/__init__.py
@@ -3,4 +3,4 @@
 SPDX-License-Identifier: MIT
 """
 
-__version__ = "3.1.3"
+__version__ = "3.1.4"

--- a/src/nextdns_mcp/client.py
+++ b/src/nextdns_mcp/client.py
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MIT
 import logging
 import posixpath
 import re
-from typing import Any, Optional
+from typing import Any
 
 import httpx
 
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 _SAFE_PROFILE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
-def extract_profile_id_from_url(url: str) -> Optional[str]:
+def extract_profile_id_from_url(url: str) -> str | None:
     """Extract profile_id from a URL path.
 
     Args:

--- a/src/nextdns_mcp/coercion.py
+++ b/src/nextdns_mcp/coercion.py
@@ -3,13 +3,12 @@
 #
 # Docker MCP CLI passes values as strings (e.g. "true" instead of true). The
 # helpers here coerce those strings to proper Python types.
-# ruff: noqa: E402
 """Type coercion utilities for NextDNS MCP Server.
 
 SPDX-License-Identifier: MIT
 """
 
-from typing import Annotated, Any, Optional
+from typing import Annotated, Any
 
 # Pydantic import for allow_extra_fields_component_fn and BeforeValidator
 try:
@@ -27,7 +26,7 @@ def _coerce_profile_id(v: object) -> object:
 
 
 _coerce_to_str = BeforeValidator(_coerce_profile_id) if BeforeValidator is not None else lambda x: x
-OptionalProfileId = Annotated[Optional[str], _coerce_to_str]
+OptionalProfileId = Annotated[str | None, _coerce_to_str]
 ProfileId = Annotated[str, _coerce_to_str]
 
 

--- a/src/nextdns_mcp/config.py
+++ b/src/nextdns_mcp/config.py
@@ -54,7 +54,7 @@ def get_api_key() -> str | None:
                 return f.read().strip()
         except FileNotFoundError:
             logger.error(f"API key file not found: {key_file}")
-        except OSError as e:
+        except (OSError, UnicodeDecodeError) as e:
             logger.error(f"Failed to read API key file: {e}")
 
     return None

--- a/src/nextdns_mcp/config.py
+++ b/src/nextdns_mcp/config.py
@@ -9,7 +9,6 @@ SPDX-License-Identifier: MIT
 import logging
 import os
 import sys
-from typing import Optional
 
 from fastmcp.server.providers.openapi import MCPType, RouteMap
 
@@ -30,8 +29,8 @@ NEXTDNS_BASE_URL = "https://api.nextdns.io"
 ALLOW_ALL_PROFILES: set[str] = set()  # Represents "ALL" profiles
 
 # Cached profile access sets (populated after validation)
-_readable_profiles_cache: Optional[set[str] | None] = None
-_writable_profiles_cache: Optional[set[str] | None] = None
+_readable_profiles_cache: set[str] | None = None
+_writable_profiles_cache: set[str] | None = None
 
 # Operations that bypass profile access control
 GLOBALLY_ALLOWED_OPERATIONS = {
@@ -40,7 +39,7 @@ GLOBALLY_ALLOWED_OPERATIONS = {
 }
 
 
-def get_api_key() -> Optional[str]:
+def get_api_key() -> str | None:
     """Get API key from environment."""
     key = os.getenv("NEXTDNS_API_KEY")
     if key:
@@ -55,7 +54,7 @@ def get_api_key() -> Optional[str]:
                 return f.read().strip()
         except FileNotFoundError:
             logger.error(f"API key file not found: {key_file}")
-        except Exception as e:
+        except OSError as e:
             logger.error(f"Failed to read API key file: {e}")
 
     return None
@@ -66,7 +65,7 @@ def get_http_timeout() -> float:
     return float(os.getenv("NEXTDNS_HTTP_TIMEOUT", "30"))
 
 
-def get_default_profile() -> Optional[str]:
+def get_default_profile() -> str | None:
     """Get default profile from environment."""
     return os.getenv("NEXTDNS_DEFAULT_PROFILE")
 

--- a/src/nextdns_mcp/openapi.py
+++ b/src/nextdns_mcp/openapi.py
@@ -157,7 +157,7 @@ class StripExtraFieldsMiddleware(Middleware):
 
                 # Update the arguments in place
                 context.message.arguments = coerced_args
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 # If we can't get the tool schema, proceed with original arguments
                 # This should rarely happen, but we don't want to break the flow
                 logger.warning(f"Could not filter arguments for tool '{tool_name}': {e}")
@@ -231,7 +231,7 @@ def allow_extra_fields_component_fn(component, *args, **kwargs):
         # Pydantic v1 (legacy compatibility)
         elif hasattr(component, "__config__"):  # pragma: no cover
 
-            class Config(getattr(component, "__config__")):  # pragma: no cover
+            class Config(component.__config__):  # pragma: no cover
                 extra = "ignore"  # pragma: no cover
 
             component.__config__ = Config  # pragma: no cover

--- a/src/nextdns_mcp/server.py
+++ b/src/nextdns_mcp/server.py
@@ -18,7 +18,6 @@
 # - Works with both OpenAPI-imported and custom @mcp_server.tool() decorated tools
 #
 # See docs/troubleshooting.md for details.
-# ruff: noqa: E402
 """NextDNS MCP Server - FastMCP-based implementation using OpenAPI spec.
 
 SPDX-License-Identifier: MIT

--- a/src/nextdns_mcp/tools/__init__.py
+++ b/src/nextdns_mcp/tools/__init__.py
@@ -33,6 +33,10 @@ from .rewrites import RewriteOperation, _manage_rewrites_impl, manageRewrites
 from .settings import _SETTINGS_PATHS, SettingsCategory, _manage_settings_impl, manageSettings
 
 __all__ = [
+    "_LIST_PATHS",
+    "_LIST_UPDATEABLE_TYPES",
+    "_PLOT_ANALYTICS_METRICS",
+    "_SETTINGS_PATHS",
     "AnalyticsMetric",
     "ListOperation",
     "ListType",
@@ -41,10 +45,6 @@ __all__ = [
     "ProfileOperation",
     "RewriteOperation",
     "SettingsCategory",
-    "_LIST_PATHS",
-    "_LIST_UPDATEABLE_TYPES",
-    "_PLOT_ANALYTICS_METRICS",
-    "_SETTINGS_PATHS",
     "_build_doh_metadata",
     "_dohLookup_impl",
     "_extract_series_label",
@@ -64,8 +64,8 @@ __all__ = [
     "_query_analytics_impl",
     "_render_series_chart",
     "_validate_record_type",
-    "doh_lookup",
     "dohLookup",
+    "doh_lookup",
     "manageLists",
     "manageLogs",
     "manageProfiles",

--- a/src/nextdns_mcp/tools/analytics.py
+++ b/src/nextdns_mcp/tools/analytics.py
@@ -3,7 +3,7 @@
 SPDX-License-Identifier: MIT
 """
 
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 from ..coercion import ProfileId
 from ..utils import _api_request, _build_query_params, _validate_profile_id
@@ -27,19 +27,19 @@ AnalyticsMetric = Literal[
 async def _query_analytics_impl(
     metric: AnalyticsMetric,
     profile_id: ProfileId,
-    from_time: Optional[str | int] = None,
-    to_time: Optional[str | int] = None,
-    interval: Optional[int] = None,
-    alignment: Optional[str] = None,
-    timezone: Optional[str] = None,
-    partials: Optional[str] = None,
-    limit: Optional[int] = None,
-    destination_type: Optional[str] = None,
+    from_time: str | int | None = None,
+    to_time: str | int | None = None,
+    interval: int | None = None,
+    alignment: str | None = None,
+    timezone: str | None = None,
+    partials: str | None = None,
+    limit: int | None = None,
+    destination_type: str | None = None,
     series: bool = False,
-    cursor: Optional[str] = None,
-    device: Optional[str] = None,
-    status: Optional[str] = None,
-    root: Optional[bool] = None,
+    cursor: str | None = None,
+    device: str | None = None,
+    status: str | None = None,
+    root: bool | None = None,
 ) -> dict[str, Any]:
     """Grouped implementation for NextDNS analytics endpoints."""
     error = _validate_profile_id(profile_id)
@@ -80,19 +80,19 @@ async def _query_analytics_impl(
 async def queryAnalytics(
     metric: AnalyticsMetric,
     profile_id: ProfileId,
-    from_time: Optional[str | int] = None,
-    to_time: Optional[str | int] = None,
-    interval: Optional[int] = None,
-    alignment: Optional[str] = None,
-    timezone: Optional[str] = None,
-    partials: Optional[str] = None,
-    limit: Optional[int] = None,
-    destination_type: Optional[str] = None,
+    from_time: str | int | None = None,
+    to_time: str | int | None = None,
+    interval: int | None = None,
+    alignment: str | None = None,
+    timezone: str | None = None,
+    partials: str | None = None,
+    limit: int | None = None,
+    destination_type: str | None = None,
     series: bool = False,
-    cursor: Optional[str] = None,
-    device: Optional[str] = None,
-    status: Optional[str] = None,
-    root: Optional[bool] = None,
+    cursor: str | None = None,
+    device: str | None = None,
+    status: str | None = None,
+    root: bool | None = None,
 ) -> dict[str, Any]:
     """Query NextDNS analytics metrics.
 

--- a/src/nextdns_mcp/tools/doh.py
+++ b/src/nextdns_mcp/tools/doh.py
@@ -69,11 +69,11 @@ async def doh_lookup(doh_url: str, domain: str, record_type: str, target_profile
             if result.get("Status") is not None:
                 logger.debug(f"DoH lookup result: {domain} -> {result['_metadata']['status_description']}")
             return result
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         error_type = "HTTP error" if isinstance(e, httpx.HTTPError) else "Unexpected error"
-        logger.error(f"{error_type} during DoH lookup for {domain}: {str(e)}")
+        logger.error(f"{error_type} during DoH lookup for {domain}: {e!s}")
         return {
-            "error": f"{error_type} during DoH lookup: {str(e)}",
+            "error": f"{error_type} during DoH lookup: {e!s}",
             "profile_id": target_profile,
             "domain": domain,
             "type": record_type,

--- a/src/nextdns_mcp/tools/lists.py
+++ b/src/nextdns_mcp/tools/lists.py
@@ -3,7 +3,7 @@
 SPDX-License-Identifier: MIT
 """
 
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal
 
 from ..coercion import ProfileId, _coerce_json_arg
 from ..utils import _api_request, _validate_entry_id, _validate_profile_id
@@ -45,7 +45,7 @@ async def _lists_get(base_url: str) -> dict[str, Any]:
     return await _api_request("GET", base_url)
 
 
-async def _lists_add(base_url: str, entry: Optional[Union[str, dict[str, Any]]]) -> dict[str, Any]:
+async def _lists_add(base_url: str, entry: str | dict[str, Any] | None) -> dict[str, Any]:
     """Add a single entry to a list."""
     if entry is None:
         return {"error": "entry is required for add operation"}
@@ -54,7 +54,7 @@ async def _lists_add(base_url: str, entry: Optional[Union[str, dict[str, Any]]])
     return await _api_request("POST", base_url, json=body)
 
 
-async def _lists_replace(base_url: str, entries: Optional[Union[str, list[dict[str, Any]]]]) -> dict[str, Any]:
+async def _lists_replace(base_url: str, entries: str | list[dict[str, Any]] | None) -> dict[str, Any]:
     """Replace the entire list with a new set of entries."""
     if entries is None:
         return {"error": "entries is required for replace operation"}
@@ -67,8 +67,8 @@ async def _lists_replace(base_url: str, entries: Optional[Union[str, list[dict[s
 async def _lists_update(
     base_url: str,
     list_type: ListType,
-    entry_id: Optional[str],
-    entry: Optional[Union[str, dict[str, Any]]],
+    entry_id: str | None,
+    entry: str | dict[str, Any] | None,
 ) -> dict[str, Any]:
     """Update a single list entry by id (only for supported list types)."""
     if list_type not in _LIST_UPDATEABLE_TYPES:
@@ -84,7 +84,7 @@ async def _lists_update(
     return await _api_request("PATCH", f"{base_url}/{entry_id}", json=entry)
 
 
-async def _lists_remove(base_url: str, entry_id: Optional[str]) -> dict[str, Any]:
+async def _lists_remove(base_url: str, entry_id: str | None) -> dict[str, Any]:
     """Remove a single list entry by id."""
     if entry_id is None:
         return {"error": "entry_id is required for remove operation"}
@@ -95,9 +95,9 @@ async def _manage_lists_impl(
     list_type: ListType,
     operation: ListOperation,
     profile_id: ProfileId,
-    entry_id: Optional[str] = None,
-    entry: Optional[Union[str, dict[str, Any]]] = None,
-    entries: Optional[Union[str, list[dict[str, Any]]]] = None,
+    entry_id: str | None = None,
+    entry: str | dict[str, Any] | None = None,
+    entries: str | list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Grouped CRUD implementation for content/privacy/security/parental lists."""
     error = _validate_profile_id(profile_id)
@@ -130,9 +130,9 @@ async def manageLists(
     list_type: ListType,
     operation: ListOperation,
     profile_id: ProfileId,
-    entry_id: Optional[str] = None,
-    entry: Optional[Union[str, dict[str, Any]]] = None,
-    entries: Optional[Union[str, list[dict[str, Any]]]] = None,
+    entry_id: str | None = None,
+    entry: str | dict[str, Any] | None = None,
+    entries: str | list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Manage allow/deny/block lists for a NextDNS profile.
 

--- a/src/nextdns_mcp/tools/logs.py
+++ b/src/nextdns_mcp/tools/logs.py
@@ -4,7 +4,7 @@ SPDX-License-Identifier: MIT
 """
 
 import logging
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 import httpx
 
@@ -21,12 +21,12 @@ LogOperation = Literal["get", "clear", "download"]
 async def _manage_logs_impl(
     operation: LogOperation,
     profile_id: ProfileId,
-    from_time: Optional[str | int] = None,
-    to_time: Optional[str | int] = None,
-    limit: Optional[int] = None,
-    user: Optional[str] = None,
-    device: Optional[str] = None,
-    raw: Optional[bool] = None,
+    from_time: str | int | None = None,
+    to_time: str | int | None = None,
+    limit: int | None = None,
+    user: str | None = None,
+    device: str | None = None,
+    raw: bool | None = None,
 ) -> dict[str, Any]:
     """Grouped implementation for query logs (get, clear, download)."""
     error = _validate_profile_id(profile_id)
@@ -73,12 +73,12 @@ async def _manage_logs_impl(
 async def manageLogs(
     operation: LogOperation,
     profile_id: ProfileId,
-    from_time: Optional[str | int] = None,
-    to_time: Optional[str | int] = None,
-    limit: Optional[int] = None,
-    user: Optional[str] = None,
-    device: Optional[str] = None,
-    raw: Optional[bool] = None,
+    from_time: str | int | None = None,
+    to_time: str | int | None = None,
+    limit: int | None = None,
+    user: str | None = None,
+    device: str | None = None,
+    raw: bool | None = None,
 ) -> dict[str, Any]:
     """Manage query logs for a NextDNS profile.
 

--- a/src/nextdns_mcp/tools/plots.py
+++ b/src/nextdns_mcp/tools/plots.py
@@ -183,7 +183,7 @@ async def _plot_analytics_series_impl(
 
     try:
         png_bytes = await asyncio.to_thread(_render_series_chart, metric, times, series_data)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         logger.error(f"Error rendering chart for {metric}: {e}")
         return {"error": f"Error rendering chart: {e}"}
 

--- a/src/nextdns_mcp/tools/profiles.py
+++ b/src/nextdns_mcp/tools/profiles.py
@@ -3,7 +3,7 @@
 SPDX-License-Identifier: MIT
 """
 
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 from ..coercion import OptionalProfileId
 from ..config import get_readable_profiles_set, get_writable_profiles_set, is_read_only
@@ -16,7 +16,7 @@ ProfileOperation = Literal["list", "create", "get", "update", "delete"]
 async def _manage_profiles_impl(
     operation: ProfileOperation,
     profile_id: OptionalProfileId = None,
-    name: Optional[str] = None,
+    name: str | None = None,
 ) -> dict[str, Any]:
     """Grouped CRUD implementation for NextDNS profiles."""
     if operation == "list":
@@ -56,7 +56,7 @@ async def _manage_profiles_impl(
 async def manageProfiles(
     operation: ProfileOperation,
     profile_id: OptionalProfileId = None,
-    name: Optional[str] = None,
+    name: str | None = None,
 ) -> dict[str, Any]:
     """Manage NextDNS profiles.
 

--- a/src/nextdns_mcp/tools/rewrites.py
+++ b/src/nextdns_mcp/tools/rewrites.py
@@ -3,7 +3,7 @@
 SPDX-License-Identifier: MIT
 """
 
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 from ..coercion import ProfileId
 from ..utils import _api_request, _validate_entry_id, _validate_profile_id
@@ -15,9 +15,9 @@ RewriteOperation = Literal["list", "add", "delete"]
 async def _manage_rewrites_impl(
     operation: RewriteOperation,
     profile_id: ProfileId,
-    name: Optional[str] = None,
-    content: Optional[str] = None,
-    entry_id: Optional[str] = None,
+    name: str | None = None,
+    content: str | None = None,
+    entry_id: str | None = None,
 ) -> dict[str, Any]:
     """Grouped CRUD implementation for DNS rewrite entries."""
     error = _validate_profile_id(profile_id)
@@ -50,9 +50,9 @@ async def _manage_rewrites_impl(
 async def manageRewrites(
     operation: RewriteOperation,
     profile_id: ProfileId,
-    name: Optional[str] = None,
-    content: Optional[str] = None,
-    entry_id: Optional[str] = None,
+    name: str | None = None,
+    content: str | None = None,
+    entry_id: str | None = None,
 ) -> dict[str, Any]:
     """Manage DNS rewrite entries for a NextDNS profile.
 

--- a/src/nextdns_mcp/tools/settings.py
+++ b/src/nextdns_mcp/tools/settings.py
@@ -3,7 +3,7 @@
 SPDX-License-Identifier: MIT
 """
 
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal
 
 from ..coercion import ProfileId, _coerce_json_arg
 from ..utils import _api_request, _validate_profile_id
@@ -27,7 +27,7 @@ async def _manage_settings_impl(
     operation: Literal["get", "update"],
     category: SettingsCategory,
     profile_id: ProfileId,
-    settings: Optional[Union[str, dict[str, Any]]] = None,
+    settings: str | dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Grouped CRUD implementation for profile settings categories."""
     error = _validate_profile_id(profile_id)
@@ -54,7 +54,7 @@ async def manageSettings(
     operation: Literal["get", "update"],
     category: SettingsCategory,
     profile_id: ProfileId,
-    settings: Optional[Union[str, dict[str, Any]]] = None,
+    settings: str | dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Manage a settings category for a NextDNS profile.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 """Pytest configuration and fixtures for NextDNS MCP Server tests."""
 
 import tempfile
+from collections.abc import Generator
 from pathlib import Path
-from typing import Generator
 from unittest.mock import patch
 
 import pytest
@@ -53,7 +53,7 @@ def set_env_api_key(monkeypatch, mock_api_key: str) -> str:
 
 
 @pytest.fixture
-def temp_api_key_file(mock_api_key: str) -> Generator[Path, None, None]:
+def temp_api_key_file(mock_api_key: str) -> Generator[Path]:
     """Create a temporary file with an API key."""
     with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
         f.write(mock_api_key)
@@ -85,7 +85,7 @@ def mock_openapi_spec() -> dict:
 
 
 @pytest.fixture
-def temp_openapi_file(mock_openapi_spec: dict) -> Generator[Path, None, None]:
+def temp_openapi_file(mock_openapi_spec: dict) -> Generator[Path]:
     """Create a temporary OpenAPI spec file."""
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
         yaml.dump(mock_openapi_spec, f)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Pytest configuration and fixtures for NextDNS MCP Server tests."""
 
 import tempfile
-from collections.abc import Generator
+from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import patch
 
@@ -53,7 +53,7 @@ def set_env_api_key(monkeypatch, mock_api_key: str) -> str:
 
 
 @pytest.fixture
-def temp_api_key_file(mock_api_key: str) -> Generator[Path]:
+def temp_api_key_file(mock_api_key: str) -> Iterator[Path]:
     """Create a temporary file with an API key."""
     with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
         f.write(mock_api_key)
@@ -85,7 +85,7 @@ def mock_openapi_spec() -> dict:
 
 
 @pytest.fixture
-def temp_openapi_file(mock_openapi_spec: dict) -> Generator[Path]:
+def temp_openapi_file(mock_openapi_spec: dict) -> Iterator[Path]:
     """Create a temporary OpenAPI spec file."""
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
         yaml.dump(mock_openapi_spec, f)

--- a/tests/integration/test_server_init.py
+++ b/tests/integration/test_server_init.py
@@ -74,14 +74,14 @@ class TestServerInitialization:
         """Test that NEXTDNS_DEFAULT_PROFILE is optional."""
         # This test is skipped because the module is already loaded with specific
         # environment variables, and reloading doesn't work reliably in pytest.
-        # pragma: no cover
+        pass  # noqa: PIE790  # pragma: no cover
 
     @pytest.mark.skip(reason="Module-level initialization prevents testing different env configs")
     def test_server_can_set_default_profile(self, monkeypatch, mock_api_key, mock_profile_id):
         """Test that default profile can be set."""
         # This test is skipped because the module is already loaded with specific
         # environment variables, and reloading doesn't work reliably in pytest.
-        # pragma: no cover
+        pass  # noqa: PIE790  # pragma: no cover
 
 
 class TestCreateMcpServer:

--- a/tests/integration/test_server_init.py
+++ b/tests/integration/test_server_init.py
@@ -17,7 +17,7 @@ class TestServerInitialization:
         # This test is skipped because the module is already imported by other tests,
         # making it impossible to test the sys.exit(1) behavior in module-level code.
         # This is a known limitation documented in /tmp/fix_test_approach.md (lines 12-13).
-        pass  # pragma: no cover
+        # pragma: no cover
 
     def test_server_module_loads_with_api_key(self, monkeypatch, mock_api_key, mock_openapi_spec):
         """Test that server module loads successfully with API key."""
@@ -74,14 +74,14 @@ class TestServerInitialization:
         """Test that NEXTDNS_DEFAULT_PROFILE is optional."""
         # This test is skipped because the module is already loaded with specific
         # environment variables, and reloading doesn't work reliably in pytest.
-        pass  # pragma: no cover
+        # pragma: no cover
 
     @pytest.mark.skip(reason="Module-level initialization prevents testing different env configs")
     def test_server_can_set_default_profile(self, monkeypatch, mock_api_key, mock_profile_id):
         """Test that default profile can be set."""
         # This test is skipped because the module is already loaded with specific
         # environment variables, and reloading doesn't work reliably in pytest.
-        pass  # pragma: no cover
+        # pragma: no cover
 
 
 class TestCreateMcpServer:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -27,7 +27,7 @@ class TestCreateNextdnsClient:
         """Test that client has correct base URL."""
         # This test is skipped because module reloading doesn't work reliably in pytest.
         # The base URL constant is already tested in test_base_url_is_correct.
-        # pragma: no cover
+        pass  # noqa: PIE790  # pragma: no cover
 
     def test_create_client_has_api_key_header(self, monkeypatch, mock_api_key):
         """Test that X-Api-Key header is set as a static header during client creation."""

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -27,7 +27,7 @@ class TestCreateNextdnsClient:
         """Test that client has correct base URL."""
         # This test is skipped because module reloading doesn't work reliably in pytest.
         # The base URL constant is already tested in test_base_url_is_correct.
-        pass  # pragma: no cover
+        # pragma: no cover
 
     def test_create_client_has_api_key_header(self, monkeypatch, mock_api_key):
         """Test that X-Api-Key header is set as a static header during client creation."""

--- a/tests/unit/test_config_api.py
+++ b/tests/unit/test_config_api.py
@@ -18,14 +18,14 @@ def patch_env(monkeypatch):
 
 def test_api_url():
     """Test API base URL constant."""
-    import nextdns_mcp.config as config
+    from nextdns_mcp import config
 
     assert config.NEXTDNS_BASE_URL == "https://api.nextdns.io"
 
 
 def test_default_api_key_empty(patch_env):
     """Test empty API key."""
-    import nextdns_mcp.config as config
+    from nextdns_mcp import config
 
     assert config.get_api_key() is None
 
@@ -33,7 +33,7 @@ def test_default_api_key_empty(patch_env):
 def test_api_key_from_env(patch_env):
     """Test API key from environment variable."""
     patch_env("NEXTDNS_API_KEY", "test-key")
-    import nextdns_mcp.config as config
+    from nextdns_mcp import config
 
     assert config.get_api_key() == "test-key"
 
@@ -43,7 +43,7 @@ def test_api_key_from_file(patch_env, tmp_path):
     key_file = tmp_path / "api-key"
     key_file.write_text("test-key-from-file")
     patch_env("NEXTDNS_API_KEY_FILE", str(key_file))
-    import nextdns_mcp.config as config
+    from nextdns_mcp import config
 
     assert config.get_api_key() == "test-key-from-file"
 
@@ -51,14 +51,14 @@ def test_api_key_from_file(patch_env, tmp_path):
 def test_api_key_file_not_found(patch_env):
     """Test missing API key file."""
     patch_env("NEXTDNS_API_KEY_FILE", "/nonexistent/file")
-    import nextdns_mcp.config as config
+    from nextdns_mcp import config
 
     assert config.get_api_key() is None
 
 
 def test_default_http_timeout(patch_env):
     """Test default HTTP timeout."""
-    import nextdns_mcp.config as config
+    from nextdns_mcp import config
 
     assert config.get_http_timeout() == 30.0
 
@@ -66,14 +66,14 @@ def test_default_http_timeout(patch_env):
 def test_custom_http_timeout(patch_env):
     """Test custom HTTP timeout."""
     patch_env("NEXTDNS_HTTP_TIMEOUT", "60")
-    import nextdns_mcp.config as config
+    from nextdns_mcp import config
 
     assert config.get_http_timeout() == 60.0
 
 
 def test_default_profile_empty(patch_env):
     """Test empty default profile."""
-    import nextdns_mcp.config as config
+    from nextdns_mcp import config
 
     assert config.get_default_profile() is None
 
@@ -81,14 +81,14 @@ def test_default_profile_empty(patch_env):
 def test_custom_default_profile(patch_env):
     """Test custom default profile."""
     patch_env("NEXTDNS_DEFAULT_PROFILE", "test-profile")
-    import nextdns_mcp.config as config
+    from nextdns_mcp import config
 
     assert config.get_default_profile() == "test-profile"
 
 
 def test_read_only_mode_default(patch_env):
     """Test default read-only mode."""
-    import nextdns_mcp.config as config
+    from nextdns_mcp import config
 
     assert not config.is_read_only()
 
@@ -96,14 +96,14 @@ def test_read_only_mode_default(patch_env):
 def test_read_only_mode_enabled(patch_env):
     """Test enabling read-only mode."""
     patch_env("NEXTDNS_READ_ONLY", "true")
-    import nextdns_mcp.config as config
+    from nextdns_mcp import config
 
     assert config.is_read_only()
 
 
 def test_globally_allowed_operations():
     """Test operations that bypass access control."""
-    import nextdns_mcp.config as config
+    from nextdns_mcp import config
 
     assert "listProfiles" in config.GLOBALLY_ALLOWED_OPERATIONS
     assert "dohLookup" in config.GLOBALLY_ALLOWED_OPERATIONS

--- a/tests/unit/test_config_constants.py
+++ b/tests/unit/test_config_constants.py
@@ -13,7 +13,7 @@ def test_dns_status_codes_contain_required_codes():
     assert 5 in DNS_STATUS_CODES  # REFUSED
 
     # Verify descriptions are present
-    for code, desc in DNS_STATUS_CODES.items():
+    for desc in DNS_STATUS_CODES.values():
         assert isinstance(desc, str)
         assert desc.strip()  # Not empty string
 

--- a/tests/unit/test_config_file.py
+++ b/tests/unit/test_config_file.py
@@ -31,7 +31,7 @@ def mock_nextdns_config():
                     return f.read().strip()
             except FileNotFoundError:
                 module.logger.error(f"API key file not found: {key_file}")
-            except Exception as e:
+            except OSError as e:
                 module.logger.error(f"Failed to read API key file: {e}")
 
         return None

--- a/tests/unit/test_config_file.py
+++ b/tests/unit/test_config_file.py
@@ -31,7 +31,7 @@ def mock_nextdns_config():
                     return f.read().strip()
             except FileNotFoundError:
                 module.logger.error(f"API key file not found: {key_file}")
-            except OSError as e:
+            except (OSError, UnicodeDecodeError) as e:
                 module.logger.error(f"Failed to read API key file: {e}")
 
         return None

--- a/tests/unit/test_config_integration.py
+++ b/tests/unit/test_config_integration.py
@@ -25,7 +25,7 @@ def test_validate_configuration_calls_sys_exit(clean_env):
     if "nextdns_mcp.config" in sys.modules:
         del sys.modules["nextdns_mcp.config"]
 
-    import nextdns_mcp.config as config
+    import nextdns_mcp.config as config  # noqa: PLR0402
 
     # Mock sys.exit to capture the call
     with patch.object(sys, "exit") as mock_exit:
@@ -44,7 +44,7 @@ def test_log_api_key_error_calls_logger(clean_env):
     # Mock logger to capture calls
     from unittest.mock import Mock
 
-    import nextdns_mcp.config as config
+    import nextdns_mcp.config as config  # noqa: PLR0402
 
     mock_logger = Mock(spec=logging.Logger)
 
@@ -69,7 +69,7 @@ def test_validate_configuration_logs_access_control(clean_env):
     # Mock logger and sys.exit
     from unittest.mock import Mock
 
-    import nextdns_mcp.config as config
+    import nextdns_mcp.config as config  # noqa: PLR0402
 
     mock_logger = Mock(spec=logging.Logger)
 

--- a/tests/unit/test_config_profiles.py
+++ b/tests/unit/test_config_profiles.py
@@ -31,7 +31,7 @@ def patch_env(monkeypatch):
 
 def test_profile_access_defaults(patch_env):
     """Test default profile access (deny all when not specified)."""
-    import nextdns_mcp.config as config
+    from nextdns_mcp import config
 
     assert not config.can_read_profile("any-profile")  # Deny all by default
     assert not config.can_write_profile("any-profile")  # Deny all by default
@@ -42,7 +42,7 @@ def test_profile_access_all(patch_env):
     patch_env("NEXTDNS_READABLE_PROFILES", "ALL")
     patch_env("NEXTDNS_WRITABLE_PROFILES", "ALL")
 
-    import nextdns_mcp.config as config
+    from nextdns_mcp import config
 
     assert config.can_read_profile("any-profile")  # Allow all
     assert config.can_write_profile("any-profile")  # Allow all
@@ -55,7 +55,7 @@ def test_readable_profiles_restricted(patch_env):
     patch_env("NEXTDNS_WRITABLE_PROFILES", "profile3")
 
     # Import after environment is set
-    import nextdns_mcp.config as config
+    from nextdns_mcp import config
 
     # Can read specified profiles
     assert config.can_read_profile("profile1")
@@ -78,7 +78,7 @@ def test_writable_profiles_restricted(patch_env):
     patch_env("NEXTDNS_READABLE_PROFILES", "profile1,profile2")
     patch_env("NEXTDNS_WRITABLE_PROFILES", "profile1,profile2")
 
-    import nextdns_mcp.config as config
+    from nextdns_mcp import config
 
     # Test write permissions
     assert config.can_write_profile("profile1")
@@ -101,7 +101,7 @@ def test_readable_profiles_include_writable(patch_env):
     patch_env("NEXTDNS_WRITABLE_PROFILES", "profile2,profile3")
 
     # Import after environment is set
-    import nextdns_mcp.config as config
+    from nextdns_mcp import config
 
     # Direct readable profiles
     assert config.can_read_profile("profile1")
@@ -127,7 +127,7 @@ def test_read_only_mode_blocks_writes(patch_env):
     patch_env("NEXTDNS_READABLE_PROFILES", "profile1,profile2")
     patch_env("NEXTDNS_WRITABLE_PROFILES", "profile1,profile2")
 
-    import nextdns_mcp.config as config
+    from nextdns_mcp import config
 
     # Verify reads still work
     assert config.can_read_profile("profile1")
@@ -149,7 +149,7 @@ def test_log_access_control_all_access(mock_logger, patch_env):
     patch_env("NEXTDNS_WRITABLE_PROFILES", "ALL")
 
     with patch("nextdns_mcp.config.logger", mock_logger):
-        import nextdns_mcp.config as config
+        from nextdns_mcp import config
 
         config._log_access_control_settings()
 
@@ -162,7 +162,7 @@ def test_log_access_control_read_only(mock_logger, patch_env):
     """Test logging in read-only mode."""
     patch_env("NEXTDNS_READ_ONLY", "true")
     with patch("nextdns_mcp.config.logger", mock_logger):
-        import nextdns_mcp.config as config
+        from nextdns_mcp import config
 
         config._log_access_control_settings()
 
@@ -177,7 +177,7 @@ def test_log_access_control_restricted(mock_logger, patch_env):
     patch_env("NEXTDNS_WRITABLE_PROFILES", "profile2")
 
     with patch("nextdns_mcp.config.logger", mock_logger):
-        import nextdns_mcp.config as config
+        from nextdns_mcp import config
 
         config._log_access_control_settings()
 

--- a/tests/unit/test_doh_lookup.py
+++ b/tests/unit/test_doh_lookup.py
@@ -123,7 +123,7 @@ class TestDohLookup:
         # This test is skipped because the module-level NEXTDNS_DEFAULT_PROFILE constant
         # is bound at import time and can't be reliably mocked. The error handling logic
         # for missing profile is simple validation code (lines 189-193 in server.py).
-        # pragma: no cover
+        pass  # noqa: PIE790  # pragma: no cover
 
     @pytest.mark.asyncio
     async def test_doh_lookup_invalid_record_type(self, mock_profile_id):

--- a/tests/unit/test_doh_lookup.py
+++ b/tests/unit/test_doh_lookup.py
@@ -123,7 +123,7 @@ class TestDohLookup:
         # This test is skipped because the module-level NEXTDNS_DEFAULT_PROFILE constant
         # is bound at import time and can't be reliably mocked. The error handling logic
         # for missing profile is simple validation code (lines 189-193 in server.py).
-        pass  # pragma: no cover
+        # pragma: no cover
 
     @pytest.mark.asyncio
     async def test_doh_lookup_invalid_record_type(self, mock_profile_id):

--- a/tests/unit/test_mcp_run_options.py
+++ b/tests/unit/test_mcp_run_options.py
@@ -67,9 +67,11 @@ class TestGetMcpRunOptions:
 
     def test_invalid_port_raises_value_error(self):
         """Test that invalid port value raises ValueError."""
-        with patch.dict(os.environ, {"MCP_TRANSPORT": "http", "MCP_PORT": "invalid"}):
-            with pytest.raises(ValueError):
-                get_mcp_run_options()
+        with (
+            patch.dict(os.environ, {"MCP_TRANSPORT": "http", "MCP_PORT": "invalid"}),
+            pytest.raises(ValueError),
+        ):
+            get_mcp_run_options()
 
     def test_options_can_be_unpacked_to_mcp_run(self):
         """Test that returned dict can be unpacked with **kwargs."""
@@ -78,5 +80,5 @@ class TestGetMcpRunOptions:
             # Simulate mcp.run(**options) - just verify dict structure
             assert isinstance(options, dict)
             # Verify all keys are valid Python identifiers (can be used as kwargs)
-            for key in options.keys():
+            for key in options:
                 assert key.isidentifier(), f"Key '{key}' is not a valid identifier"

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -269,11 +269,13 @@ class TestAllowExtraFieldsComponentFn:
             __config__ = OldConfig
 
         # Make it look like a BaseModel subclass by patching isinstance check
-        with patch("nextdns_mcp.openapi.isinstance", side_effect=lambda obj, cls: True):
-            with patch("nextdns_mcp.openapi.issubclass", side_effect=lambda obj, cls: True):
-                # This is tricky - the function checks isinstance(component, type)
-                # and issubclass(component, BaseModel), but we're mocking those
-                pass
+        with (
+            patch("nextdns_mcp.openapi.isinstance", side_effect=lambda obj, cls: True),
+            patch("nextdns_mcp.openapi.issubclass", side_effect=lambda obj, cls: True),
+        ):
+            # This is tricky - the function checks isinstance(component, type)
+            # and issubclass(component, BaseModel), but we're mocking those
+            pass
 
         # Alternative: directly test the v1 branch behavior is correct
         # by verifying our v2 model gets the right config applied

--- a/tests/unit/test_server_additional_coverage.py
+++ b/tests/unit/test_server_additional_coverage.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import ClassVar
 
 import httpx
 import pytest
@@ -57,7 +58,7 @@ def test_coerce_json_arg_invalid_json_returns_value():
 
 
 class DummyTool:
-    parameters: dict[str, object] = {"properties": {"keep": {"type": "boolean"}}}
+    parameters: ClassVar[dict[str, object]] = {"properties": {"keep": {"type": "boolean"}}}
 
 
 class DummyToolManager:
@@ -103,7 +104,7 @@ async def test_strip_extra_fields_middleware_basic_and_exception():
 
     # String-typed identifier-like values must not be coerced
     class StringDummyTool:
-        parameters: dict[str, object] = {"properties": {"profile_id": {"type": "string"}}}
+        parameters: ClassVar[dict[str, object]] = {"properties": {"profile_id": {"type": "string"}}}
 
     class StringToolManager:
         async def get_tool(self, name):

--- a/tests/unit/test_transport_config.py
+++ b/tests/unit/test_transport_config.py
@@ -54,6 +54,5 @@ def test_custom_host_and_port():
 
 def test_invalid_port_raises_error():
     """Verify invalid port value raises ValueError."""
-    with patch.dict(os.environ, {"MCP_PORT": "invalid"}):
-        with pytest.raises(ValueError):
-            int(os.getenv("MCP_PORT", "8000"))
+    with patch.dict(os.environ, {"MCP_PORT": "invalid"}), pytest.raises(ValueError):
+        int(os.getenv("MCP_PORT", "8000"))

--- a/uv.lock
+++ b/uv.lock
@@ -24,11 +24,11 @@ wheels = [
 
 [[package]]
 name = "annotated-types"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
 ]
 
 [[package]]
@@ -139,11 +139,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "7.1.4"
+version = "7.1.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/af/861ebc2e318a5c3300e3eb63bc4d30f3d70a46d13b360093728ac0705eed/cachetools-7.1.6.tar.gz", hash = "sha256:c7a79e7f30ba9943c1cefd08cc36f006aaae086e017af9166f1d59d6170c47e1", size = 40572, upload-time = "2026-07-23T22:47:53.737Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f2/2086ba18a925a73586c4d4e61d25f4a6058e56fd00d77ce8f1d361ab4c9b/cachetools-7.1.6-py3-none-any.whl", hash = "sha256:2c12e255780330af28b91bb7fb96cce4c766f04e38396b9a24510190a5827096", size = 16954, upload-time = "2026-07-23T22:47:52.397Z" },
 ]
 
 [[package]]
@@ -161,11 +161,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.6.17"
+version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -416,7 +416,7 @@ wheels = [
 
 [[package]]
 name = "cyclopts"
-version = "4.21.2"
+version = "4.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -424,9 +424,9 @@ dependencies = [
     { name = "rich" },
     { name = "rich-rst" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/3c/86729ac28bfcd82d8d5967432e805e9c9f3299d07ebfa15f443ea46b11c6/cyclopts-4.21.2.tar.gz", hash = "sha256:62e31e4ffd1a1aefd6d2a74b42075a4b0e9c949431663d90190f1fa07dbc2ced", size = 193107, upload-time = "2026-07-19T00:56:55.862Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/98/ca72a91d5c25a2ae1baf19d27b31f12288cb9d8a3168b65b3cd54d40d277/cyclopts-4.22.2.tar.gz", hash = "sha256:0721e90e7209885e78f7637cfba255c12e89206b633e35d185305e349ba20ecd", size = 194511, upload-time = "2026-07-24T20:53:08.739Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/5d/f297fe15d33c63e2fcff0487e00af13ada1687a0accd282a2f042bf5360d/cyclopts-4.21.2-py3-none-any.whl", hash = "sha256:507420e40cc6d74f6cbf20a137b612657fe7254c6765eb569ba3d93775ac5f20", size = 232473, upload-time = "2026-07-19T00:56:54.247Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/75/a11bfb5045e58b4ef69337b848985918e829fe9a90572a761d17c1a992f5/cyclopts-4.22.2-py3-none-any.whl", hash = "sha256:9c2cdf6a621886cd0af631a67437eb7d0084f33f9e8fba2d2562a1aecf75f2ff", size = 233906, upload-time = "2026-07-24T20:53:07.064Z" },
 ]
 
 [[package]]
@@ -683,14 +683,14 @@ wheels = [
 
 [[package]]
 name = "joserfc"
-version = "1.7.3"
+version = "1.7.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/c6/b1cac0280f8efc57626ea8804866b37099f23cae11b1485a42b213245e31/joserfc-1.7.3.tar.gz", hash = "sha256:116955c2587139dba20621fd0bd7fc9255fa960c9fe7f43c43ebef2e801dcfcf", size = 233821, upload-time = "2026-07-08T12:41:42.66Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/e0/27a6a081ae25420eda6768ceae05d7022a7f2447f420588843f2a44e4298/joserfc-1.7.4.tar.gz", hash = "sha256:b3bc561672ae541b17a9237053b48a03dacddd92d68047b3ecdfb4b5714a88ed", size = 234027, upload-time = "2026-07-19T15:43:02.739Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/f5/650b59d1b74f5befb7a7a7e7d7c92a26b94256df3541e2b4914152cd177a/joserfc-1.7.3-py3-none-any.whl", hash = "sha256:7c39f3f2c943dbc03122747fa8ebbd8e156e54904cf25651b452f4d2634a6075", size = 70982, upload-time = "2026-07-08T12:41:41.521Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/249dcd99b3376375910b7fa922383b57792975c8758f50d44612e749226c/joserfc-1.7.4-py3-none-any.whl", hash = "sha256:32d46c2cd5e3203c13e87a6c61333cab310b1ba80cd54b4c4f386a848a122463", size = 71000, upload-time = "2026-07-19T15:43:01.299Z" },
 ]
 
 [[package]]
@@ -976,7 +976,7 @@ wheels = [
 
 [[package]]
 name = "nextdns-mcp"
-version = "3.1.3"
+version = "3.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -1152,11 +1152,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.10.1"
+version = "4.11.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/cd/4f25b2f95b23f5d2c9c1fe43e49841bff5800562149b2666afc09309aa8f/platformdirs-4.10.1.tar.gz", hash = "sha256:ceab4084426fe6319ce18e86deada8ab1b7487c7aee7040c55e277c9ae793695", size = 31678, upload-time = "2026-07-18T03:53:43.808Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/73/6fd0bb9ce84138c3857f12e9de63bc901852975a092d545f18087a204aa2/platformdirs-4.10.1-py3-none-any.whl", hash = "sha256:0e4eff26be2d75293977f7cddc153fd9b8eaa7fb0c7b64ffe4076cb443117443", size = 22906, upload-time = "2026-07-18T03:53:42.576Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
 ]
 
 [[package]]
@@ -1592,27 +1592,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.22"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/06/ae069393fc66e8ff33036d4b368003833bf6e88ccf182e17e7a2f1c754fd/ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809", size = 4785063, upload-time = "2026-07-16T15:14:13.244Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/18/ee54b7ae1e121be7a28ea6da4b67564ebb0530e183a54415ab7e3bcd2c4e/ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8", size = 10781258, upload-time = "2026-07-16T15:13:19.452Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/d2/2520cb14761ddbeaf57642a76942fc36adcbdbe53b4532241995f6fc485c/ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697", size = 10999477, upload-time = "2026-07-16T15:13:23.318Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/10/74e53572aa758dfaa678c2a2646b5c5515d884b7ca56be4d2ce03ca4b560/ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f", size = 10466716, upload-time = "2026-07-16T15:13:26.162Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/cc/44eaaf0844e028182f2d0a8f2190d0f359159aed0a9e5ab861d892f1ae2a/ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576", size = 10892644, upload-time = "2026-07-16T15:13:29.229Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/21/8edf559014d2b0f82beea19cfb713993ad802ccda16868769979c6090a84/ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178", size = 10576719, upload-time = "2026-07-16T15:13:32.35Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/1e/3a13abd392a3b50b62e5938a831f9ab6e588358cacad5c18545b716d2182/ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224", size = 11376494, upload-time = "2026-07-16T15:13:35.958Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3e/422d3d95bcf04dd78e1aeac22184d4f9a8fb2c01865d39d44618484a0317/ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a", size = 12208370, upload-time = "2026-07-16T15:13:39.185Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/91/5d065a0e0a02bf4813f5119ad278462eed081d2b832eb7c021ade0ec9e65/ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e", size = 11581098, upload-time = "2026-07-16T15:13:42.132Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb", size = 11399422, upload-time = "2026-07-16T15:13:45.2Z" },
-    { url = "https://files.pythonhosted.org/packages/18/80/c843a5176cddbceb0b7e8dd41cf9993490796c1c469348d384f5a5c13c56/ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74", size = 11381683, upload-time = "2026-07-16T15:13:48.46Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/00/8485de0ae92239438a36cfc51350db9b9e85c9ebdfaea91b18e422706662/ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c", size = 10850295, upload-time = "2026-07-16T15:13:51.655Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/91/24977ec2ec72eaf15e4394ace2959fdff2dd1e14f03e005e838023407169/ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296", size = 10579640, upload-time = "2026-07-16T15:13:54.79Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/47/9b51216951974df1f263ac19da550d34252e0ed7218c25f10c5ef9ed7517/ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262", size = 11105077, upload-time = "2026-07-16T15:13:57.915Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/47/20e9d4a3b8016778acea5fc32bb50d35d207500a17ddb529ffa6996feef8/ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64", size = 11490980, upload-time = "2026-07-16T15:14:01.032Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165, upload-time = "2026-07-16T15:14:04.16Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297, upload-time = "2026-07-16T15:14:07.316Z" },
-    { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172, upload-time = "2026-07-16T15:14:10.51Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]
@@ -1639,15 +1639,15 @@ wheels = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.4.5"
+version = "3.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/1b/bc9e3e7a72dcdad7dc7888758f5d00f56f8909ed5cfdff822bd72bb4c520/sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a", size = 35249, upload-time = "2026-06-20T17:36:58.322Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/10/a34c656829ffc1c4b22ef36d70d9ebb6b99c020e2aeb17cee5485099f028/sse_starlette-3.4.6.tar.gz", hash = "sha256:725f8a1bd6d26ae1b2c9610c0ef5065dfdd496f3988d28adcf8c4b49dc25c627", size = 32542, upload-time = "2026-07-20T14:16:32.201Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/75/c88d3f5dafd59c791da1ce27650d30bf5b70cbf1cbf01cd00e5f9e360915/sse_starlette-3.4.5-py3-none-any.whl", hash = "sha256:e71bad53323f65573c3864a6c3bd0c1eb6e5f092b2e48082b0c35927d19ca296", size = 16518, upload-time = "2026-06-20T17:36:56.729Z" },
+    { url = "https://files.pythonhosted.org/packages/49/36/e10c1d1b7ca881d2625db2ec28508578499187bb1c389952c398474e1834/sse_starlette-3.4.6-py3-none-any.whl", hash = "sha256:56217ab4c9a9f9c5db7b21e08732d3e7c2b807f45231ad23de0551a24c4a41f6", size = 16516, upload-time = "2026-07-20T14:16:30.978Z" },
 ]
 
 [[package]]
@@ -1664,11 +1664,11 @@ wheels = [
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.20260518"
+version = "6.0.12.20260724"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/6f/a28f44bcd56bebed42b028a2894c79853e2f5e6b5279e633cb3f287a05e7/types_pyyaml-6.0.12.20260724.tar.gz", hash = "sha256:3c1ce1bb73cd5ec02e90390c2b1f00e810d241d8825fd73ff359696839271b6b", size = 17893, upload-time = "2026-07-24T04:58:43.453Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/42/0337fefc615e20ee55d1c8f71b774a9b2b734a04669139c20753b27a2a3a/types_pyyaml-6.0.12.20260724-py3-none-any.whl", hash = "sha256:d57db930a4b2efbc57cf430ec8882765d246929432fa253092f383902329a453", size = 20312, upload-time = "2026-07-24T04:58:42.486Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated dependency updates via `uv lock --upgrade` (bump version to 3.1.4) and resolution of new lint rules in ruff 0.16.0.