### PR TITLE
chore(repo): add GitHub Sponsors funding button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github:
+  - dmeiser


### PR DESCRIPTION
Adds a GitHub sponsor button for @dmeiser per the GitHub documentation for displaying a sponsor button in a repository (https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/customizing-your-repository/displaying-a-sponsor-button-in-your-repository).