### PR TITLE
chore(repo): match GitHub sample FUNDING.yml format

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,3 @@
-github:
-  - dmeiser
+# These are supported funding model platforms
+
+github: [dmeiser] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]


### PR DESCRIPTION
Updates  to match the exact sample format GitHub expects, which should make the sponsor button appear.